### PR TITLE
Update pytest to also test the logging functionality in daqpytools

### DIFF
--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -129,7 +129,7 @@ class FormattedRichHandler(RichHandler):
 
         padding = LOG_RECORD_PADDING.get("logger_name", 45)
         logger_name_text: Text = Text(
-            f"{record.name}:".ljust(padding)[:padding], style="logging.logger_name"
+            f"{record.name}".ljust(padding)[:padding], style="logging.logger_name"
         )
 
         # Convert message_renderable to Text for type consistency

--- a/src/daqpytools/logging/log_format.ini
+++ b/src/daqpytools/logging/log_format.ini
@@ -5,7 +5,7 @@
 time = 25
 level = 10
 file_and_line = 40
-logger_name = 40
+logger_name = 45
 
 [logging]
 # Logging format configuration

--- a/src/daqpytools/logging/log_format.ini
+++ b/src/daqpytools/logging/log_format.ini
@@ -5,7 +5,7 @@
 time = 25
 level = 10
 file_and_line = 40
-logger_name = 45
+logger_name = 50
 
 [logging]
 # Logging format configuration

--- a/src/daqpytools/logging/log_format.ini
+++ b/src/daqpytools/logging/log_format.ini
@@ -38,7 +38,7 @@ timezone=UTC
 # Combine styles and colors, e.g., "bold magenta", "dim cyan", "bold white on red"
 logging.time = dim blue
 logging.location = dim white
-logging.logger_name = bright_yellow
+logging.logger_name = dim white
 
 # === Log level colors ===
 logging.level.debug = dim cyan

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -18,7 +18,7 @@ def validate_setup_configuration(
     logger_name: str, rich_handler: bool, stdout_handler: bool, stderr_handler: bool
 ) -> None:
     """Checks for one or less stream-type handler associated with the logger."""
-    if sum([rich_handler, stdout_handler, stderr_handler]) > 1:
+    if rich_handler and any([stdout_handler, stderr_handler]):
         err_msg = (
             "All instances of rich_handler, stdout_handler, and std_err will log "
             "to the tty, choose one!"
@@ -27,8 +27,12 @@ def validate_setup_configuration(
     return
 
 
-def setup_root_logger(name: str, level: int) -> logging.Logger:
+def setup_root_logger(name: str, level: int | str) -> logging.Logger:
     """Set up the base logger from which all other loggers inherit."""
+
+    if isinstance(level, str):
+        level = log_level_to_int(level)
+
     root_logger = logging.getLogger(name)
     root_logger.setLevel(level)
 
@@ -64,8 +68,7 @@ def get_daq_logger(
     )
     log_level = log_level_to_int(log_level)
 
-    root_logger_name: str = logger_name
-    logger: logging.Logger = setup_root_logger(name=root_logger_name, level=log_level)
+    logger: logging.Logger = setup_root_logger(name=logger_name, level=log_level)
     logger.propagate = use_parent_handlers
 
     if rich_handler:
@@ -76,4 +79,8 @@ def get_daq_logger(
         add_stdout_handler(logger, use_parent_handlers)
     if stream_stderr_handler:
         add_stderr_handler(logger, use_parent_handlers)
+
+    for handler in logger.handlers:
+        handler.setLevel(log_level)
+
     return logger

--- a/tests/logging/test_utils.py
+++ b/tests/logging/test_utils.py
@@ -1,8 +1,11 @@
 import pytest
+import tempfile
+import logging
 
-from daqpytools.logging.exceptions import LogLevelError
+from daqpytools.logging.exceptions import LogLevelError, LoggerSetupError
 from daqpytools.logging.levels import logging_log_levels, oks_log_levels
 from daqpytools.logging.utils import log_level_to_int
+from daqpytools.logging.logger import get_daq_logger
 
 test_log_level_str = "INFO"
 oks_log_level_str = "kDefault"
@@ -42,3 +45,90 @@ def test_unknown_int_to_logging_int():
     """Validate the conversion of an unknown logging level int raises an error."""
     with pytest.raises(LogLevelError):
         log_level_to_int(test_unknown_log_level_int)
+
+
+def test_setup_logger(caplog):
+    temp_file = tempfile.NamedTemporaryFile()
+    log_path = temp_file.name
+    
+    # Setup root logger
+    root_logger: logging.Logger = get_daq_logger(
+        logger_name="root",
+        log_level= "DEBUG",
+        use_parent_handlers=True,
+        rich_handler=True,
+        file_handler_path=log_path,
+        stream_stdout_handler=False,
+        stream_stderr_handler=False,
+    )
+
+    # Test if logging level set to what what it was initialised with
+    assert root_logger.getEffectiveLevel() == logging.DEBUG
+
+    # Test if logging level can be changed
+    root_logger.setLevel("INFO")
+    assert root_logger.getEffectiveLevel() == logging.INFO
+
+    root_logger.setLevel("WARNING")
+    assert root_logger.getEffectiveLevel() == logging.WARNING
+    
+    root_logger.setLevel("ERROR")
+    assert root_logger.getEffectiveLevel() == logging.ERROR
+
+    root_logger.setLevel("CRITICAL")
+    assert root_logger.getEffectiveLevel() == logging.CRITICAL
+
+    # Generate a child logger. Test that by default this is initialised with log level INFO    
+    # This is the case even if the parent logger has a different log level
+    assert get_daq_logger("tester0").getEffectiveLevel() == logging.INFO
+
+    # Test if a new child logger can be initialised with a different log level
+    assert get_daq_logger("tester1", "WARNING").getEffectiveLevel() == logging.WARNING
+
+    # Test if the child logger can be changed
+    get_daq_logger("tester1").setLevel("INFO")
+    assert get_daq_logger("tester1").getEffectiveLevel() == logging.INFO
+
+    # Test logging to a file
+    logger = get_daq_logger("tester2", "CRITICAL")
+    logger.debug("invisible")
+    logger.info("invisible")
+    logger.warning("invisible")
+    logger.error("invisible")
+    logger.critical("VISIBLE")
+    good_record = 0
+    bad_record = 0
+    for record in caplog.records:
+        if (
+            "VISIBLE" in record.getMessage()
+            and record.levelno == logging.CRITICAL
+            and "tester2" in record.name
+        ):
+            good_record += 1
+        else:
+            bad_record += 1
+
+    assert good_record == 1
+    assert bad_record == 0
+
+    with open(log_path) as f:
+        temp_file_data = f.read()
+        assert "VISIBLE" in temp_file_data
+        assert "invisible" not in temp_file_data
+
+    temp_file.close()
+
+    # Test if loggers fail to initialise with conflicting handlers
+    with pytest.raises(LoggerSetupError):
+        failing_logger: logging.Logger = get_daq_logger(
+            logger_name="root",
+            log_level= "DEBUG",
+            use_parent_handlers=True,
+            rich_handler=True,
+            file_handler_path=log_path,
+            stream_stdout_handler=True,
+            stream_stderr_handler=True,
+        )
+
+
+


### PR DESCRIPTION
# Description

https://github.com/DUNE-DAQ/drunc/pull/633 revealed that the logging testing should be done in this repository instead of drunc. This pull request moves the old testing function removed in https://github.com/DUNE-DAQ/drunc/pull/633/commits/b8043403bd35513b4b67576ae37352eba3d9cb48 to here, along with adding some extra tests.



Test by running `pytest`


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Passed local pytest

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [x] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))


## TODO:
- [ ] Run pre-commit

