### PR TITLE
Many minor fixes to the handlers implementation

### DIFF
--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -38,7 +38,12 @@ def validate_test_configuration(
 
 
 
-def test_main_functions(main_logger):
+def test_main_functions(main_logger:logging.Logger) -> None:
+    """Demonstrates the main functionality of the daqpytools logger.
+    
+    Args:
+        main_logger (logging.Logger): A logger to print messages with
+    """
     main_logger.debug("example debug message")
     main_logger.info("example info message")
     main_logger.warning("example warning message")
@@ -68,51 +73,78 @@ def test_main_functions(main_logger):
     )
 
 def test_child_logger(
-        logger_name,
-        log_level,
-        disable_logger_inheritance,
-        rich_handler,
-        file_handler_path,
-        stream_handlers
-):
-        nested_logger: logging.Logger = get_daq_logger(
-            logger_name=f"{logger_name}.child",
-            log_level=log_level,
-            use_parent_handlers=not disable_logger_inheritance,
-            rich_handler=rich_handler,
-            file_handler_path=file_handler_path,
-            stream_handlers=stream_handlers,
-        )
-        nested_logger.debug("example debug message")
-        nested_logger.info("example info message")
-        nested_logger.warning("example warning message")
-        nested_logger.error("example error message")
-        nested_logger.critical("example critical message")
-        nested_logger.info(
-            "[dim cyan]You[/dim cyan] "
-            "[bold green]can[/bold green] "
-            "[bold yellow]also[/bold yellow] "
-            "[bold red]add[/bold red] "
-            "[bold white on red]colours[/bold white on red] "
-            "[bold red]to[/bold red] "
-            "[bold yellow]your[/bold yellow] "
-            "[bold green]log[/bold green] "
-            "[dim cyan]record[/dim cyan] "
-            "[bold green]text[/bold green] "
-            "[bold yellow]with[/bold yellow] "
-            "[bold green]markdown[/bold green]!"
-        )
-        nested_logger.warning(
-            "Note: [red] the daqpytools.logging.formatter removes markdown-style "
-            "comments from the log record message [/red]."
-        )
+        logger_name:str,
+        log_level: int|str,
+        disable_logger_inheritance:bool,
+        rich_handler:bool,
+        file_handler_path: str,
+        stream_handlers:bool,
+) -> None:
+    """Demonstrates inheritance with child handlers.
 
-def test_throttle(main_logger):
-    
-    emit_err = lambda i: main_logger.info(
-        f"Throttle test {i}",
-        extra={"handlers": [HandlerType.Rich, HandlerType.Throttle]},
+    Args:
+        logger_name (str): Name of the initial parent logger.
+        log_level (str): Log level to set for the logger.
+        
+        disable_logger_inheritance (bool): If true, disable logger inheritance so each
+            logger instance only uses the logger handlers assigned to the given logger
+            instance.
+        rich_handler (bool): If true, set up a rich handler.
+        file_handler_path (str): If provided, set up a file handler with the given path.
+        stream_handlers (bool): If true, set up stdout and stderr stream handlers.
+    """
+    nested_logger: logging.Logger = get_daq_logger(
+        logger_name=f"{logger_name}.child",
+        log_level=log_level,
+        use_parent_handlers=not disable_logger_inheritance,
+        rich_handler=rich_handler,
+        file_handler_path=file_handler_path,
+        stream_handlers=stream_handlers,
     )
+    nested_logger.debug("example debug message")
+    nested_logger.info("example info message")
+    nested_logger.warning("example warning message")
+    nested_logger.error("example error message")
+    nested_logger.critical("example critical message")
+    nested_logger.info(
+        "[dim cyan]You[/dim cyan] "
+        "[bold green]can[/bold green] "
+        "[bold yellow]also[/bold yellow] "
+        "[bold red]add[/bold red] "
+        "[bold white on red]colours[/bold white on red] "
+        "[bold red]to[/bold red] "
+        "[bold yellow]your[/bold yellow] "
+        "[bold green]log[/bold green] "
+        "[dim cyan]record[/dim cyan] "
+        "[bold green]text[/bold green] "
+        "[bold yellow]with[/bold yellow] "
+        "[bold green]markdown[/bold green]!"
+    )
+    nested_logger.warning(
+        "Note: [red] the daqpytools.logging.formatter removes markdown-style "
+        "comments from the log record message [/red]."
+    )
+
+def test_throttle(main_logger: logging.Logger) -> None:
+    """Demonstrates the throttle filter.
+    
+    Args:
+        main_logger (logging.Logger): A logger to print messages with
+    """
+    def emit_err(i: int) -> None:
+        """Short function that prints out a log message.
+        This is used to ensure that the log message is kept on the same line,
+        but also to feed in how many repetitions it has gone through
+        Args:
+            i (int): Integer to be transmitted in the log message.
+
+        Returns:
+            None.
+        """
+        throttle_msg = f"Throttle test {i}"
+        main_logger.info(throttle_msg, extra={"handlers": 
+            [HandlerType.Rich, HandlerType.Throttle]
+        })
     
     for i in range(50):
         emit_err(i)
@@ -122,7 +154,12 @@ def test_throttle(main_logger):
         emit_err(i)
     
 
-def test_handlertypes(main_logger):
+def test_handlertypes(main_logger: logging.Logger) -> None:
+    """Demonstrates the handlertype functionality.
+    
+    Args:
+        main_logger (logging.Logger): A logger to print messages with
+    """
     #* Test choosing which handler to use individually
     main_logger.debug("Default go to tty / rich / file when added")
     main_logger.critical("Should only go to tty", 
@@ -142,7 +179,12 @@ def test_handlertypes(main_logger):
     )
 
 
-def test_handlerconf(main_logger):
+def test_handlerconf(main_logger: logging.Logger) -> None:
+    """Demonstrates the main functionality of the handlerconf. With ERS support.
+    
+    Args:
+        main_logger (logging.Logger): A logger to print messages with
+    """
     #* Test the routing to the Base and Opmon streams
     handlerconf = LogHandlerConf(init_ers=False) # False is the default
     main_logger.warning("Handlerconf Base", extra=handlerconf.Base)
@@ -169,7 +211,7 @@ def test_handlerconf(main_logger):
     # HandlerConf will require that these variables are defined!
     # They come from the OKS, so whatever tools you have should have this up
     # You can also initialise via handlerconf = LogHandlerConf(init_ers=True)
-    handlerconf.init_ERS()
+    handlerconf.init_ers_stream()
     
     #* Test ERS Streams
     main_logger.warning("ERS Warning erstrace,throttle,lstdout", extra=handlerconf.ERS)
@@ -293,8 +335,8 @@ def main(
         handlerconf (bool): If true, demonstrates the advanced feature of HandlerConf
             and streams.
         throttle (bool): If true, demonstrates the throttling feature. Requires Rich.
-        supress_basic (bool): If true, supresses basic functionality. Useful to only test 
-            the advanced features of logging
+        suppress_basic (bool): If true, supresses basic functionality. 
+            Useful to only test the advanced features of logging
 
     Returns:
         None
@@ -302,7 +344,6 @@ def main(
     Raises:
         LoggerSetupError: If no handlers are set up for the logger.
     """
-
     logger_name = "daqpytools_logging_demonstrator"
     main_logger: logging.Logger = get_daq_logger(
         logger_name=logger_name,

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -226,14 +226,25 @@ def test_handlerconf(main_logger: logging.Logger) -> None:
     )     
 
 class AllOptionsCommand(click.Command):
-    """
-    Parse the arguments passed and validate they are acceptable, otherwise print the
-    relevant options
+    """Parse the arguments passed and validate they are acceptable, otherwise print the
+    relevant options.
 
     Click's default functionality does not pick up the optional arguments well. This
     catches any incorrect options or typos, makes the log clearer.
     """
-    def parse_args(self, ctx: click.Context, args: list[str]):
+    def parse_args(self, ctx: click.Context, args: list[str]) -> None:
+        """Parse the arguments passed to the click command, format them if necessary.
+
+        Args:
+            ctx: click context from which the commands are called
+            args: list of args to format
+
+        Returns:
+            None
+
+        Raises:
+            None
+        """
         # If the arguments are valid, run the command with the relevant arguments
         try:
             return super().parse_args(ctx, args)

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -37,6 +37,139 @@ def validate_test_configuration(
     return
 
 
+
+def test_main_functions(main_logger):
+    main_logger.debug("example debug message")
+    main_logger.info("example info message")
+    main_logger.warning("example warning message")
+    main_logger.error("example error message")
+    main_logger.critical("example critical message")
+    main_logger.info(
+        "[dim cyan]You[/dim cyan] "
+        "[bold green]can[/bold green] "
+        "[bold yellow]also[/bold yellow] "
+        "[bold red]add[/bold red] "
+        "[bold white on red]colours[/bold white on red] "
+        "[bold red]to[/bold red] "
+        "[bold yellow]your[/bold yellow] "
+        "[bold green]log[/bold green] "
+        "[dim cyan]record[/dim cyan] "
+        "[bold green]text[/bold green] "
+        "[bold yellow]with[/bold yellow] "
+        "[bold green]markdown[/bold green]!"
+    )
+    main_logger.warning(
+        "Note: [red] the daqpytools.logging.formatter removes markdown-style "
+        "comments from the log record message [/red]."
+    )
+
+def test_child_logger(
+        logger_name,
+        log_level,
+        disable_logger_inheritance,
+        rich_handler,
+        file_handler_path,
+        stream_handlers
+):
+        nested_logger: logging.Logger = get_daq_logger(
+            logger_name=f"{logger_name}.child",
+            log_level=log_level,
+            use_parent_handlers=not disable_logger_inheritance,
+            rich_handler=rich_handler,
+            file_handler_path=file_handler_path,
+            stream_handlers=stream_handlers,
+        )
+        nested_logger.debug("example debug message")
+        nested_logger.info("example info message")
+        nested_logger.warning("example warning message")
+        nested_logger.error("example error message")
+        nested_logger.critical("example critical message")
+        nested_logger.info(
+            "[dim cyan]You[/dim cyan] "
+            "[bold green]can[/bold green] "
+            "[bold yellow]also[/bold yellow] "
+            "[bold red]add[/bold red] "
+            "[bold white on red]colours[/bold white on red] "
+            "[bold red]to[/bold red] "
+            "[bold yellow]your[/bold yellow] "
+            "[bold green]log[/bold green] "
+            "[dim cyan]record[/dim cyan] "
+            "[bold green]text[/bold green] "
+            "[bold yellow]with[/bold yellow] "
+            "[bold green]markdown[/bold green]!"
+        )
+        nested_logger.warning(
+            "Note: [red] the daqpytools.logging.formatter removes markdown-style "
+            "comments from the log record message [/red]."
+        )
+
+def test_throttle(main_logger):
+    
+    emit_err = lambda i: main_logger.info(
+        f"Throttle test {i}",
+        extra={"handlers": [HandlerType.Rich, HandlerType.Throttle]},
+    )
+    
+    for i in range(50):
+        emit_err(i)
+    main_logger.warning("Sleeping for 30 seconds")
+    time.sleep(31)
+    for i in range(1000):
+        emit_err(i)
+    
+
+def test_handlertypes(main_logger):
+    #* Test choosing which handler to use individually
+    main_logger.debug("Default go to tty / rich / file when added")
+    main_logger.critical("Should only go to tty", 
+        extra={"handlers": [HandlerType.Rich]}
+    )
+    main_logger.critical("Should only go to file", 
+        extra={"handlers": [HandlerType.File]}
+    )
+    main_logger.critical("Should only go to Lstdout",
+        extra={"handlers": [HandlerType.Lstdout]}
+    )
+    main_logger.critical("Should only go to Throttle",
+        extra={"handlers": [HandlerType.Throttle]}
+    )
+    main_logger.critical("Should go to tty and Protobufstream", 
+        extra={"handlers": [HandlerType.Rich, HandlerType.Protobufstream]}
+    )
+
+
+def test_handlerconf(main_logger):
+    #* Interlude: Inject sample environment variables
+    os.environ["DUNEDAQ_ERS_WARNING"] = "erstrace,throttle,lstdout"
+    os.environ["DUNEDAQ_ERS_INFO"] = "erstrace,throttle,lstdout"
+    os.environ["DUNEDAQ_ERS_FATAL"] = "erstrace,lstdout"
+    os.environ["DUNEDAQ_ERS_ERROR"] = (
+        "erstrace,"
+        "throttle,"
+        "lstdout,"
+        "protobufstream(monkafka.cern.ch:30092)"
+    )
+        
+    info_out = f"{os.getenv('DUNEDAQ_ERS_ERROR')=}"
+    main_logger.info(info_out)
+    critical_out = f"{os.getenv('DUNEDAQ_ERS_CRITICAL')=}"
+    main_logger.info(critical_out)
+
+    #* Test the routing to the Base and Opmon streams
+    handlerconf = LogHandlerConf()
+    main_logger.warning("Handlerconf Base", extra=handlerconf.Base)
+    main_logger.warning("Handlerconf Opmon", extra=handlerconf.Opmon)
+
+    #* Test ERS Streams
+    main_logger.warning("ERS Warning erstrace,throttle,lstdout", extra=handlerconf.ERS)
+    main_logger.info("ERS Info erstrace,throttle,lstdout", extra=handlerconf.ERS)
+    main_logger.critical("ERS Fatal erstrace,lstdout", extra=handlerconf.ERS)
+    main_logger.debug("ERS Debug none", extra=handlerconf.ERS)
+    main_logger.error("ERS Error erstrace,throttle,lstdout,"
+        "protobufstream(monkafka.cern.ch:30092)", 
+        extra=handlerconf.ERS
+    )     
+
 @click.command()
 @click.option(
     "-l",
@@ -67,6 +200,20 @@ def validate_test_configuration(
     is_flag=True, 
     help=(
         "Demonstrate HandlerTypes functionality"
+        )
+    )
+@click.option(
+    "--handlerconf", 
+    is_flag=True, 
+    help=(
+        "Demonstrate HandlerConf functionality"
+        )
+    )
+@click.option(
+    "--suppress-basic", 
+    is_flag=True, 
+    help=(
+        "Suppress demonstration of basic logging functionality"
         )
     )
 @click.option(
@@ -110,7 +257,9 @@ def main(
     disable_logger_inheritance: bool,
     ersprotobufstream: bool,
     handlertypes:bool,
+    handlerconf:bool,
     throttle: bool,
+    suppress_basic: bool
 ) -> None:
     """Demonstrate use of the daq_logging class with daqpyutils_logging_demonstrator.
     Note - if you are seeing output logs without any explicit handlers assigned, this is
@@ -127,11 +276,14 @@ def main(
             logger instance only uses the logger handlers assigned to the given logger
             instance.
         ersprotobufstream (bool): If true, sets up an ERS protobuf handler. Error msg
-            are demonstrated in the HandlerType demonstration, requiring handlertypes
+            are demonstrated in the HandlerType demonstration, requiring handlerconf
             to be set to true.
-        handlertypes (bool): If true, demonstrates the advanced feature of HandlerTypes
+        handlertypes (bool): If true, demonstrates the advanced feature of HandlerTypes.
+        handlerconf (bool): If true, demonstrates the advanced feature of HandlerConf
             and streams.
         throttle (bool): If true, demonstrates the throttling feature. Requires Rich.
+        supress_basic (bool): If true, supresses basic functionality. Useful to only test 
+            the advanced features of logging
 
     Returns:
         None
@@ -139,8 +291,8 @@ def main(
     Raises:
         LoggerSetupError: If no handlers are set up for the logger.
     """
-    logger_name = "daqpytools_logging_demonstrator"
 
+    logger_name = "daqpytools_logging_demonstrator"
     main_logger: logging.Logger = get_daq_logger(
         logger_name=logger_name,
         log_level=log_level,
@@ -151,145 +303,26 @@ def main(
         ers_kafka_handler=ersprotobufstream,
         throttle=throttle
     )
-    main_logger.debug("example debug message")
-    main_logger.info("example info message")
-    main_logger.warning("example warning message")
-    main_logger.error("example error message")
-    main_logger.critical("example critical message")
-    main_logger.info(
-        "[dim cyan]You[/dim cyan] "
-        "[bold green]can[/bold green] "
-        "[bold yellow]also[/bold yellow] "
-        "[bold red]add[/bold red] "
-        "[bold white on red]colours[/bold white on red] "
-        "[bold red]to[/bold red] "
-        "[bold yellow]your[/bold yellow] "
-        "[bold green]log[/bold green] "
-        "[dim cyan]record[/dim cyan] "
-        "[bold green]text[/bold green] "
-        "[bold yellow]with[/bold yellow] "
-        "[bold green]markdown[/bold green]!"
-    )
-    main_logger.warning(
-        "Note: [red] the daqpytools.logging.formatter removes markdown-style "
-        "comments from the log record message [/red]."
-    )
 
-    if child_logger:
-        nested_logger: logging.Logger = get_daq_logger(
-            logger_name=f"{logger_name}.child",
-            log_level=log_level,
-            use_parent_handlers=not disable_logger_inheritance,
-            rich_handler=rich_handler,
-            file_handler_path=file_handler_path,
-            stream_handlers=stream_handlers,
-        )
-        nested_logger.debug("example debug message")
-        nested_logger.info("example info message")
-        nested_logger.warning("example warning message")
-        nested_logger.error("example error message")
-        nested_logger.critical("example critical message")
-        nested_logger.info(
-            "[dim cyan]You[/dim cyan] "
-            "[bold green]can[/bold green] "
-            "[bold yellow]also[/bold yellow] "
-            "[bold red]add[/bold red] "
-            "[bold white on red]colours[/bold white on red] "
-            "[bold red]to[/bold red] "
-            "[bold yellow]your[/bold yellow] "
-            "[bold green]log[/bold green] "
-            "[dim cyan]record[/dim cyan] "
-            "[bold green]text[/bold green] "
-            "[bold yellow]with[/bold yellow] "
-            "[bold green]markdown[/bold green]!"
-        )
-        nested_logger.warning(
-            "Note: [red] the daqpytools.logging.formatter removes markdown-style "
-            "comments from the log record message [/red]."
-        )
-
-
-    # Throttle demo
-    def emit_err(i: int) -> None:
-        """Short function that prints out a log message.
-        This is used to ensure that the log message is kept on the same line,
-        but also to feed in how many repetitions it has gone through
-        Args:
-            i (int): Integer to be transmitted in the log message.
-
-        Returns:
-            None.
-        """
-        throttle_msg = f"Throttle test {i}"
-        main_logger.info(throttle_msg, extra={"handlers": 
-            [HandlerType.Rich, HandlerType.Throttle]
-        })
+    if not suppress_basic:
+        test_main_functions(main_logger)
     
+    if child_logger: 
+        test_child_logger(
+            logger_name,
+            log_level,
+            disable_logger_inheritance,
+            rich_handler,
+            file_handler_path,
+            stream_handlers
+        )
+
     if throttle:
-        for i in range(50):
-            emit_err(i)
-        main_logger.warning("Sleeping for 30 seconds")
-        time.sleep(31)
-        for i in range(1000):
-            emit_err(i)
-
-
-
-    # HandlerTypes demo
-    if not handlertypes:
-        return
-
-    #* Test choosing which handler to use individually
-    main_logger.debug("Default go to tty / rich / file when added")
-    main_logger.critical("Should only go to tty", 
-        extra={"handlers": [HandlerType.Rich]}
-    )
-    main_logger.critical("Should only go to file", 
-        extra={"handlers": [HandlerType.File]}
-    )
-    main_logger.critical("Should only go to Lstdout",
-        extra={"handlers": [HandlerType.Lstdout]}
-    )
-    main_logger.critical("Should only go to Throttle",
-        extra={"handlers": [HandlerType.Throttle]}
-    )
-    main_logger.critical("Should go to tty and Protobufstream", 
-        extra={"handlers": [HandlerType.Rich, HandlerType.Protobufstream]}
-    )
-
-    
-    #* Interlude: Inject sample environment variables
-    os.environ["DUNEDAQ_ERS_WARNING"] = "erstrace,throttle,lstdout"
-    os.environ["DUNEDAQ_ERS_INFO"] = "erstrace,throttle,lstdout"
-    os.environ["DUNEDAQ_ERS_FATAL"] = "erstrace,lstdout"
-    os.environ["DUNEDAQ_ERS_ERROR"] = (
-        "erstrace,"
-        "throttle,"
-        "lstdout,"
-        "protobufstream(monkafka.cern.ch:30092)"
-    )
-        
-    info_out = f"{os.getenv('DUNEDAQ_ERS_ERROR')=}"
-    main_logger.info(info_out)
-    critical_out = f"{os.getenv('DUNEDAQ_ERS_CRITICAL')=}"
-    main_logger.info(critical_out)
-
-    #* Test the routing to the Base and Opmon streams
-    handlerconf = LogHandlerConf()
-    main_logger.warning("Handlerconf Base", extra=handlerconf.Base)
-    main_logger.warning("Handlerconf Opmon", extra=handlerconf.Opmon)
-
-    #* Test ERS Streams
-    main_logger.warning("ERS Warning erstrace,throttle,lstdout", extra=handlerconf.ERS)
-    main_logger.info("ERS Info erstrace,throttle,lstdout", extra=handlerconf.ERS)
-    main_logger.critical("ERS Fatal erstrace,lstdout", extra=handlerconf.ERS)
-    main_logger.debug("ERS Debug none", extra=handlerconf.ERS)
-    main_logger.error("ERS Error erstrace,throttle,lstdout,"
-        "protobufstream(monkafka.cern.ch:30092)", 
-        extra=handlerconf.ERS
-    ) 
-    
-    return
+        test_throttle(main_logger)
+    if handlertypes:
+        test_handlertypes(main_logger)
+    if handlerconf:
+        test_handlerconf(main_logger)
 
 
 if __name__ == "__main__":

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -143,6 +143,11 @@ def test_handlertypes(main_logger):
 
 
 def test_handlerconf(main_logger):
+    #* Test the routing to the Base and Opmon streams
+    handlerconf = LogHandlerConf(init_ers=False) # False is the default
+    main_logger.warning("Handlerconf Base", extra=handlerconf.Base)
+    main_logger.warning("Handlerconf Opmon", extra=handlerconf.Opmon)
+
     #* Interlude: Inject sample environment variables
     os.environ["DUNEDAQ_ERS_WARNING"] = "erstrace,throttle,lstdout"
     os.environ["DUNEDAQ_ERS_INFO"] = "erstrace,throttle,lstdout"
@@ -159,11 +164,13 @@ def test_handlerconf(main_logger):
     critical_out = f"{os.getenv('DUNEDAQ_ERS_CRITICAL')=}"
     main_logger.info(critical_out)
 
-    #* Test the routing to the Base and Opmon streams
-    handlerconf = LogHandlerConf()
-    main_logger.warning("Handlerconf Base", extra=handlerconf.Base)
-    main_logger.warning("Handlerconf Opmon", extra=handlerconf.Opmon)
-
+    #* Init ERS stream
+    # Note to developers:
+    # HandlerConf will require that these variables are defined!
+    # They come from the OKS, so whatever tools you have should have this up
+    # You can also initialise via handlerconf = LogHandlerConf(init_ers=True)
+    handlerconf.init_ERS()
+    
     #* Test ERS Streams
     main_logger.warning("ERS Warning erstrace,throttle,lstdout", extra=handlerconf.ERS)
     main_logger.info("ERS Info erstrace,throttle,lstdout", extra=handlerconf.ERS)

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -6,6 +6,7 @@ import click
 from rich.traceback import install as rich_traceback_install
 
 from daqpytools.logging.exceptions import LoggerSetupError
+from daqpytools.logging.formatter import CONTEXT_SETTINGS
 from daqpytools.logging.handlers import (
     HandlerType,
     LogHandlerConf,
@@ -224,7 +225,46 @@ def test_handlerconf(main_logger: logging.Logger) -> None:
         extra=handlerconf.ERS
     )     
 
-@click.command()
+class AllOptionsCommand(click.Command):
+    """
+    Parse the arguments passed and validate they are acceptable, otherwise print the
+    relevant options
+
+    Click's default functionality does not pick up the optional arguments well. This
+    catches any incorrect options or typos, makes the log clearer.
+    """
+    def parse_args(self, ctx: click.Context, args: list[str]):
+        # If the arguments are valid, run the command with the relevant arguments
+        try:
+            return super().parse_args(ctx, args)
+        except click.NoSuchOption as e:
+            # Get the list of available options, format them in a readable way
+            formatted_opts = []
+            
+            for param in self.params:
+                if isinstance(param, click.Option) and param.opts:
+                    # For each option, format as "short_opt (long_opt)"
+                    opts = sorted(param.opts, key=len)
+                    
+                    if len(opts) > 1:
+                        # Multiple options
+                        formatted_opts.append(f"{opts[0]} ({opts[1]})")
+                    else:
+                        # One long option
+                        formatted_opts.append(opts[0])
+            
+            # Inform the user why what they have tried to use is wrong
+            click.echo(ctx.get_usage() + "\n", err=True)
+            
+            # Print formatted available options
+            msg = (
+                f"Error: No such option: {e.option_name}. \n"
+                f"Available options: {', '.join(sorted(formatted_opts))}"
+            )
+            click.echo(msg, err=True)
+            ctx.exit(2)
+
+@click.command(cls=AllOptionsCommand, context_settings=CONTEXT_SETTINGS)
 @click.option(
     "-l",
     "--log-level",
@@ -232,7 +272,7 @@ def test_handlerconf(main_logger: logging.Logger) -> None:
     default="DEBUG",
     help="Set the log level.",
 )
-@click.option("-r", "--rich_handler", is_flag=True, help=("Set up a rich handler"))
+@click.option("-r", "--rich-handler", is_flag=True, help=("Set up a rich handler"))
 @click.option(
     "-f",
     "--file-handler-path",
@@ -243,6 +283,7 @@ def test_handlerconf(main_logger: logging.Logger) -> None:
     ),
 )
 @click.option(
+    "-e",
     "--ersprotobufstream", 
     is_flag=True, 
     help=(
@@ -250,6 +291,7 @@ def test_handlerconf(main_logger: logging.Logger) -> None:
         )
     )
 @click.option(
+    "-ht",
     "--handlertypes", 
     is_flag=True, 
     help=(
@@ -257,6 +299,7 @@ def test_handlerconf(main_logger: logging.Logger) -> None:
         )
     )
 @click.option(
+    "-hc",
     "--handlerconf", 
     is_flag=True, 
     help=(
@@ -264,6 +307,7 @@ def test_handlerconf(main_logger: logging.Logger) -> None:
         )
     )
 @click.option(
+    "-sb",
     "--suppress-basic", 
     is_flag=True, 
     help=(
@@ -280,7 +324,7 @@ def test_handlerconf(main_logger: logging.Logger) -> None:
     )
 @click.option(
     "-s",
-    "--stream_handlers",
+    "--stream-handlers",
     is_flag=True,
     help=("Set up stdout and stderr stream handlers"),
 )

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -42,6 +42,10 @@ def test_main_functions(main_logger):
     main_logger.debug("example debug message")
     main_logger.info("example info message")
     main_logger.warning("example warning message")
+    
+    # Error and critical will print twice when using stream handlers
+    # This is because StreamHandlers add in a stream each for stdout and stderr
+    # stderr log level set to error, so at error or above both handlers will fire
     main_logger.error("example error message")
     main_logger.critical("example critical message")
     main_logger.info(

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -156,6 +156,7 @@ def test_throttle(main_logger: logging.Logger) -> None:
 
 def test_handlertypes(main_logger: logging.Logger) -> None:
     """Demonstrates the handlertype functionality.
+    Note - to have the messages published, the relevant handlers must be enabled.
     
     Args:
         main_logger (logging.Logger): A logger to print messages with
@@ -330,7 +331,7 @@ def main(
             instance.
         ersprotobufstream (bool): If true, sets up an ERS protobuf handler. Error msg
             are demonstrated in the HandlerType demonstration, requiring handlerconf
-            to be set to true.
+            to be set to true. The topic for these tests is session_tester.
         handlertypes (bool): If true, demonstrates the advanced feature of HandlerTypes.
         handlerconf (bool): If true, demonstrates the advanced feature of HandlerConf
             and streams.

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -196,7 +196,8 @@ class LogHandlerConf:
     """Dataclass that holds the various streams and relevant handlers.
     
     Attributes:
-        init_ers: If True, automatically initializes ERS configuration during construction.
+        init_ers: If True, automatically initializes ERS configuration 
+            during construction.
         _BASE_HANDLERS: Private class variable for default base handlers
         _OPMON_HANDLERS: Private class variable for opmon handlers
         BASE_CONFIG: Class variable for base stream configuration
@@ -222,7 +223,7 @@ class LogHandlerConf:
         "stream": StreamType.OPMON
     }
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Initialize ERS configuration if init_ers field is True.
 
         This method is called automatically after dataclass initialization.
@@ -230,23 +231,25 @@ class LogHandlerConf:
         ERS initialization.
         """
         if self.init_ers:
-            self.init_ERS()
+            self.init_ers_stream()
 
     @property
-    def ERS(self):
+    def ERS(self) -> dict : # noqa: N802
         """Get the ERS configuration dictionary.
         
         Returns:
             dict: Contains 'ers_handlers' and 'stream' configuration for ERS
             
         Raises:
-            AttributeError: If ERS has not been initialized (call init_ERS() first)
+            AttributeError: If ERS has not been
+                initialized (call init_ers_stream() first)
         """
         if not self._ERS:
-            raise AttributeError("ERS stream not initialised. Call init_ERS() first")
+            err_msg = "ERS stream not initialised. Call init_ers_stream() first"
+            raise AttributeError(err_msg)
         return self._ERS
 
-    def init_ERS(self):
+    def init_ers_stream(self) -> None:
         """Initialize ERS configuration from environment variables.
         
         Loads ERS configuration from OKS environment variables and populates

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -196,18 +196,21 @@ class LogHandlerConf:
     """Dataclass that holds the various streams and relevant handlers.
     
     Attributes:
+        init_ers: If True, automatically initializes ERS configuration during construction.
         _BASE_HANDLERS: Private class variable for default base handlers
         _OPMON_HANDLERS: Private class variable for opmon handlers
         BASE_CONFIG: Class variable for base stream configuration
         OPMON_CONFIG: Class variable for opmon stream configuration
         ERS: Instance field for ERS configuration (loaded from environment)
     """
+    init_ers: bool = False
 
     _BASE_HANDLERS: ClassVar[set] = {HandlerType.Stream, HandlerType.Rich,
         HandlerType.File
         }
     _OPMON_HANDLERS: ClassVar[set] = {HandlerType.Rich, HandlerType.Stream,
         HandlerType.File}
+    _ERS: object = None
     
     Base: ClassVar[dict] = {
         "handlers": _BASE_HANDLERS,
@@ -219,12 +222,43 @@ class LogHandlerConf:
         "stream": StreamType.OPMON
     }
 
-    ERS: dict=field(default_factory = lambda:
-    {
-        "ers_handlers":  LogHandlerConf._get_oks_conf(),
-        "stream": StreamType.ERS
-    }
-    )
+    def __post_init__(self):
+        """Initialize ERS configuration if init_ers field is True.
+
+        This method is called automatically after dataclass initialization.
+        If the init_ers attribute was set to True, it triggers the complete
+        ERS initialization.
+        """
+        if self.init_ers:
+            self.init_ERS()
+
+    @property
+    def ERS(self):
+        """Get the ERS configuration dictionary.
+        
+        Returns:
+            dict: Contains 'ers_handlers' and 'stream' configuration for ERS
+            
+        Raises:
+            AttributeError: If ERS has not been initialized (call init_ERS() first)
+        """
+        if not self._ERS:
+            raise AttributeError("ERS stream not initialised. Call init_ERS() first")
+        return self._ERS
+
+    def init_ERS(self):
+        """Initialize ERS configuration from environment variables.
+        
+        Loads ERS configuration from OKS environment variables and populates
+        the _ERS dict with handlers and stream information.
+        
+        Called automatically during construction if init_ers=True, or can be
+        called manually afterwards.
+        """
+        self._ERS = {
+            "ers_handlers":  LogHandlerConf._get_oks_conf(),
+            "stream": StreamType.ERS
+        }   
 
     @staticmethod
     def _convert_str_to_handlertype(handler_str: str) -> tuple[HandlerType,

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -1,6 +1,7 @@
 import logging
 from logging import PlaceHolder
 
+import sys
 import kafka
 import sh
 from rich.traceback import install as rich_traceback_install
@@ -159,7 +160,7 @@ def get_daq_logger(
     if log_level is not logging.NOTSET:
         for handler in logger.handlers:
             # Ignore stderr handler resets, needs to be fixed at the error level
-            if type(handler).__name__ == "StderrHandler":
+            if isinstance(handler, logging.StreamHandler) and handler.stream == sys.stderr:
                 continue
             handler.setLevel(log_level)
 

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -1,7 +1,7 @@
 import logging
+import sys
 from logging import PlaceHolder
 
-import sys
 import kafka
 import sh
 from rich.traceback import install as rich_traceback_install
@@ -160,7 +160,8 @@ def get_daq_logger(
     if log_level is not logging.NOTSET:
         for handler in logger.handlers:
             # Ignore stderr handler resets, needs to be fixed at the error level
-            if isinstance(handler, logging.StreamHandler) and handler.stream == sys.stderr:
+            if (isinstance(handler, logging.StreamHandler)
+                and handler.stream == sys.stderr):
                 continue
             handler.setLevel(log_level)
 


### PR DESCRIPTION
# Description

Dependent on #37 going in. Alternatively, this can be merged into #37, after which that can go in. 
Up to you Mr. Reviewer.


These have a few minor fixes that were discovered when implementing ERS into drunc and quality of life fixes

## Changes

Three major changes are done:

### Refactor logging demonstrator

Fixes #45

Logging demonstrator has become a behemoth of a monolith. This was a quick refactor that splits it off into various functions that that are all called in main. It should make things more readable and maintainable.

### Fixes a streamhandler bug

Fixes #44 

See above issue for description. This is now fixed by using the actual enums instead of strings to refer to things in the ERS.


### Introduces better initialisation of the LHC

The LogHandlerConf by default initialises all the Base, Opmon, and ERS streams all at once. This is not always desired, because there are cases where we do want to initialise the base stream but not have to worry about ERS. This would be an issue because ERS _requires_ the ERS env variables to be defined, when they are not always defined.

This fixes it by introducing a separate initialisation function, which is controlled by a new variable/argument of `init_ers`. 
So the functionality is now as follows.

```python

# Previous behaviour. Setting to true will initialise the ERS streams on the creation of handlerconf
# requires ERS envs to be defined
LHC_init = LogHandlerConf(init_ers=True)

# new behaviour (and now default!)
# By default init_ers is false
# When this is the case, ERS Streams are _not_ defined. Will survive without ERS envs being defined
LHC_no_init = LogHandlerConf() == LogHandlerConf(init_ers=False)

print(LHC_no_init.Base) # Success
print(LHC_no_init.ERS) # Throws ERS stream not initialised. Call init_ERS() first

# Later on, when ERS envs are defined, can be initialised
LHC_no_init.init_ERS() 
print(LHC_no_init.ERS) # Success

```


## Reviewer test

- Check out this branch on latest nightly
- Run the logging demonstrator script with all the relevant options. Everything should work as expected.
- For inspiration, run `daqpytools-logging-demonstrator -r -f logger.log --ersprotobufstream --handlertypes --handlerconf -t -s `
- Check that:
  - the example messages print. there should be two (rich and stream)
  - An exception is the error and critical. There should be _three_ (rich, stdout and stderr)
  - Throttle works. There should be two blocks, one is 40 msg, then 30s wait, then over 200 msg
  - Check handlertypes work. Messages should go where they say they go (rich goes to rich, file goes to file)
  - Check handlerconf works. They should go where they are directed to (see handler.py)
  - Check ers works. View on kafk
- Feel free to run the above LHC ERS init to test as well


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)



## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

