### PR TITLE
Major refactor of handlers

### DIFF
--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -10,8 +10,7 @@ from daqpytools.logging.formatter import CONTEXT_SETTINGS
 from daqpytools.logging.handlerconf import LogHandlerConf
 from daqpytools.logging.handlers import (
     HandlerType,
-    add_stderr_handler,
-    add_stdout_handler,
+    add_handler,
 )
 from daqpytools.logging.levels import logging_log_level_keys
 from daqpytools.logging.logger import get_daq_logger, setup_daq_ers_logger
@@ -165,7 +164,7 @@ def test_handlertypes(main_logger: logging.Logger) -> None:
         main_logger (logging.Logger): A logger to print messages with
     """
     #* Test choosing which handler to use individually
-    main_logger.debug("Default go to tty / rich / file when added")
+    main_logger.debug("Default go to whatever handlers were initialised with")
     main_logger.critical("Should only go to tty", 
         extra={"handlers": [HandlerType.Rich]}
     )
@@ -246,9 +245,19 @@ def test_fallback_handlers(log_level: str) -> None:
 
     fallback_log.info("Rich Only")
     
-    add_stdout_handler(fallback_log, True)
-    add_stderr_handler(fallback_log, True, {HandlerType.Unknown})
+    add_handler(
+        fallback_log,
+        HandlerType.Lstdout,
+        True
+    )
 
+    add_handler(
+        fallback_log,
+        HandlerType.Lstderr,
+        True,
+        fallback_handler = {HandlerType.Unknown}
+    )
+    
     fallback_log.critical("Rich + stdout only")
     fallback_log.critical(
         "Rich + stdout + stderr",
@@ -266,8 +275,8 @@ def test_ers_handler_configuration(log_level: str) -> None:
         None
     """
     # Injecting specific 
-    os.environ["DUNEDAQ_ERS_WARNING"] = "lstdout"
-    os.environ["DUNEDAQ_ERS_INFO"] = "rich"
+    os.environ["DUNEDAQ_ERS_WARNING"] = "rich"
+    os.environ["DUNEDAQ_ERS_INFO"] = "lstdout"
     os.environ["DUNEDAQ_ERS_FATAL"] = "lstderr,rich"
     os.environ["DUNEDAQ_ERS_ERROR"] = "rich"
 
@@ -284,7 +293,7 @@ def test_ers_handler_configuration(log_level: str) -> None:
     ers_logger.info("ERS configured, but should still only be rich")
     
     ers_hc = LogHandlerConf(init_ers=True)
-    ers_logger.info("ERS Info rich ", extra=ers_hc.ERS)
+    ers_logger.info("ERS Info lstdout ", extra=ers_hc.ERS)
     ers_logger.warning("ERS error lstdout", extra=ers_hc.ERS)
     ers_logger.critical("ERS critical lstderr + rich", extra=ers_hc.ERS)
 

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -494,7 +494,8 @@ def main(
         rich_handler=rich_handler,
         file_handler_path=file_handler_path,
         stream_handlers=stream_handlers,
-        ers_kafka_handler=ersprotobufstream,
+        ers_kafka_session=ersprotobufstream,
+        ers_app_name="Custom App Name", # Can be none!
         throttle=throttle
     )
 

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -296,7 +296,7 @@ class AllOptionsCommand(click.Command):
 @click.option(
     "-e",
     "--ersprotobufstream", 
-    is_flag=True, 
+    type=str,
     help=(
         "Set up an ERS handler, and publish to ERS"
         )
@@ -364,7 +364,7 @@ def main(
     stream_handlers: bool,
     child_logger: bool,
     disable_logger_inheritance: bool,
-    ersprotobufstream: bool,
+    ersprotobufstream: str,
     handlertypes:bool,
     handlerconf:bool,
     throttle: bool,
@@ -384,7 +384,7 @@ def main(
         disable_logger_inheritance (bool): If true, disable logger inheritance so each
             logger instance only uses the logger handlers assigned to the given logger
             instance.
-        ersprotobufstream (bool): If true, sets up an ERS protobuf handler. Error msg
+        ersprotobufstream (str): Sets up an ERS protobuf handler with supplied session name. Error msg
             are demonstrated in the HandlerType demonstration, requiring handlerconf
             to be set to true. The topic for these tests is session_tester.
         handlertypes (bool): If true, demonstrates the advanced feature of HandlerTypes.

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -7,9 +7,9 @@ from rich.traceback import install as rich_traceback_install
 
 from daqpytools.logging.exceptions import LoggerSetupError
 from daqpytools.logging.formatter import CONTEXT_SETTINGS
+from daqpytools.logging.handlerconf import LogHandlerConf
 from daqpytools.logging.handlers import (
     HandlerType,
-    LogHandlerConf,
     add_stderr_handler,
     add_stdout_handler,
 )

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -275,11 +275,14 @@ def test_ers_handler_configuration(log_level: str) -> None:
         logger_name="ers_logger",
         log_level=log_level,
         stream_handlers=False,
-        rich_handler=False,
+        rich_handler=True,
     )
+    ers_logger.info("Just rich is added")
+   
     # Sets up the logger with all the relevant handlers
     setup_daq_ers_logger(ers_logger, "session_temp")
-
+    ers_logger.info("ERS configured, but should still only be rich")
+    
     ers_hc = LogHandlerConf(init_ers=True)
     ers_logger.info("ERS Info rich ", extra=ers_hc.ERS)
     ers_logger.warning("ERS error lstdout", extra=ers_hc.ERS)

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -10,9 +10,9 @@ from daqpytools.logging.formatter import CONTEXT_SETTINGS
 from daqpytools.logging.handlers import (
     HandlerType,
     LogHandlerConf,
+    add_stderr_handler,
     add_stdout_handler,
 )
-
 from daqpytools.logging.levels import logging_log_level_keys
 from daqpytools.logging.logger import get_daq_logger, setup_daq_ers_logger
 from daqpytools.logging.utils import get_width
@@ -227,6 +227,65 @@ def test_handlerconf(main_logger: logging.Logger) -> None:
         extra=handlerconf.ERS
     )     
 
+
+def test_fallback_handlers(log_level: str) -> None:
+    """Demonstrate fallback handler behavior for a logger.
+
+    Args:
+        log_level (str): Log level used to initialize the demo logger.
+
+    Returns:
+        None
+    """
+    fallback_log: logging.Logger = get_daq_logger(
+        logger_name="fallback_logger",
+        log_level=log_level,
+        stream_handlers=False,
+        rich_handler=True,
+    )
+
+    fallback_log.info("Rich Only")
+    
+    add_stdout_handler(fallback_log, True)
+    add_stderr_handler(fallback_log, True, {HandlerType.Unknown})
+
+    fallback_log.critical("Rich + stdout only")
+    fallback_log.critical(
+        "Rich + stdout + stderr",
+        extra={"handlers": [HandlerType.Rich, HandlerType.Stream]},
+    )
+
+    
+def test_ers_handler_configuration(log_level: str) -> None:
+    """Demonstrate ERS-driven handler configuration for a logger.
+
+    Args:
+        log_level (str): Log level used to initialize the demo logger.
+
+    Returns:
+        None
+    """
+    # Injecting specific 
+    os.environ["DUNEDAQ_ERS_WARNING"] = "lstdout"
+    os.environ["DUNEDAQ_ERS_INFO"] = "rich"
+    os.environ["DUNEDAQ_ERS_FATAL"] = "lstderr,rich"
+    os.environ["DUNEDAQ_ERS_ERROR"] = "rich"
+
+    ers_logger: logging.Logger = get_daq_logger(
+        logger_name="ers_logger",
+        log_level=log_level,
+        stream_handlers=False,
+        rich_handler=False,
+    )
+    # Sets up the logger with all the relevant handlers
+    setup_daq_ers_logger(ers_logger, "session_temp")
+
+    ers_hc = LogHandlerConf(init_ers=True)
+    ers_logger.info("ERS Info rich ", extra=ers_hc.ERS)
+    ers_logger.warning("ERS error lstdout", extra=ers_hc.ERS)
+    ers_logger.critical("ERS critical lstderr + rich", extra=ers_hc.ERS)
+
+
 class AllOptionsCommand(click.Command):
     """Parse the arguments passed and validate they are acceptable, otherwise print the
     relevant options.
@@ -296,11 +355,19 @@ class AllOptionsCommand(click.Command):
     ),
 )
 @click.option(
-    "-e",
+    "-ep",
     "--ersprotobufstream", 
     type=str,
     help=(
-        "Set up an ERS handler, and publish to ERS"
+        "Set up an ERS protobuf handler, and publish to ERS via protobuf."
+        )
+    )
+@click.option(
+    "-eh",
+    "--ershandlers",
+    is_flag=True,
+    help=(
+        "Demonstrate automatic logger configuration with ers variables."
         )
     )
 @click.option(
@@ -359,6 +426,14 @@ class AllOptionsCommand(click.Command):
         "logger handlers assigned to the given logger instance"
     ),
 )
+@click.option(
+    "-fh",
+    "--fallback-handlers",
+    is_flag=True,
+    help=(
+        "If true, demonstrates the use of fallback handlers."
+    ),
+)
 def main(
     log_level: str,
     rich_handler: bool,
@@ -370,7 +445,10 @@ def main(
     handlertypes:bool,
     handlerconf:bool,
     throttle: bool,
-    suppress_basic: bool
+    suppress_basic: bool,
+    fallback_handlers: bool,
+    ershandlers: bool,
+
 ) -> None:
     """Demonstrate use of the daq_logging class with daqpyutils_logging_demonstrator.
     Note - if you are seeing output logs without any explicit handlers assigned, this is
@@ -386,7 +464,8 @@ def main(
         disable_logger_inheritance (bool): If true, disable logger inheritance so each
             logger instance only uses the logger handlers assigned to the given logger
             instance.
-        ersprotobufstream (str): Sets up an ERS protobuf handler with supplied session name. Error msg
+        ersprotobufstream (str): Sets up an ERS protobuf handler with supplied
+            session name. Error msg
             are demonstrated in the HandlerType demonstration, requiring handlerconf
             to be set to true. The topic for these tests is session_tester.
         handlertypes (bool): If true, demonstrates the advanced feature of HandlerTypes.
@@ -395,6 +474,8 @@ def main(
         throttle (bool): If true, demonstrates the throttling feature. Requires Rich.
         suppress_basic (bool): If true, supresses basic functionality. 
             Useful to only test the advanced features of logging
+        fallback_handlers (bool): If true, demonstrates fallback handler behavior.
+        ershandlers (bool): If true, demonstrates ERS-based handler setup.
 
     Returns:
         None
@@ -403,95 +484,40 @@ def main(
         LoggerSetupError: If no handlers are set up for the logger.
     """
     logger_name = "daqpytools_logging_demonstrator"
-
-    os.environ["DUNEDAQ_ERS_WARNING"] = "erstrace,throttle,lstderr"
-    os.environ["DUNEDAQ_ERS_INFO"] = "lstderr,throttle,lstderr"
-    os.environ["DUNEDAQ_ERS_FATAL"] = "lstderr"
-    os.environ["DUNEDAQ_ERS_ERROR"] = (
-        "erstrace,"
-        "throttle,"
-        "lstderr,"
-        "protobufstream(monkafka.cern.ch:30092)"
-    )
-
-    handlerconf = LogHandlerConf(init_ers=True)
-
     main_logger: logging.Logger = get_daq_logger(
         logger_name=logger_name,
         log_level=log_level,
-        stream_handlers=False,
-        rich_handler=True # only rich was defined
+        use_parent_handlers=not disable_logger_inheritance,
+        rich_handler=rich_handler,
+        file_handler_path=file_handler_path,
+        stream_handlers=stream_handlers,
+        ers_kafka_handler=ersprotobufstream,
+        throttle=throttle
     )
 
-    main_logger.warning("Only Rich")
-
-    # add_stdout_handler(main_logger, True)
-    setup_daq_ers_logger(main_logger, "session_temp")
-
-    main_logger.critical("Should be only rich")
-
-
-    # main_logger.critical("test") #use only rich because we only iniitlaise with rich
-
-    main_logger.critical("Stream", extra={"handlers": [HandlerType.Stream]})
-
+    if not suppress_basic:
+        test_main_functions(main_logger)
     
-    
-    main_logger.critical("ERS (lstderr only)", extra=handlerconf.ERS)
+    if child_logger: 
+        test_child_logger(
+            logger_name,
+            log_level,
+            disable_logger_inheritance,
+            rich_handler,
+            file_handler_path,
+            stream_handlers
+        )
 
-    
-
-
-
-    # define a default handlerconf so for example 
-
-
-    """
-    Concrete suggestions
-
-    For now:
-    get_daq_logger = rich_handler = True  # save rich_handler and set as base class
-
-    setup_ers(log) #adds stream handler and what have you
-    
-    log.warning("something") # only goes to rich because we only initialise with rich
-
-    log.warning("something else", extra= ers) # use whatever is in ers
-    
-    """
-
-
-    # main_logger: logging.Logger = get_daq_logger(
-    #     logger_name=logger_name,
-    #     log_level=log_level,
-    #     use_parent_handlers=not disable_logger_inheritance,
-    #     rich_handler=rich_handler,
-    #     file_handler_path=file_handler_path,
-    #     stream_handlers=stream_handlers,
-    #     ers_kafka_handler=ersprotobufstream,
-    #     throttle=throttle
-    # )
-
-    # if not suppress_basic:
-    #     test_main_functions(main_logger)
-    
-    # if child_logger: 
-    #     test_child_logger(
-    #         logger_name,
-    #         log_level,
-    #         disable_logger_inheritance,
-    #         rich_handler,
-    #         file_handler_path,
-    #         stream_handlers
-    #     )
-
-    # if throttle:
-    #     test_throttle(main_logger)
-    # if handlertypes:
-    #     test_handlertypes(main_logger)
-    # if handlerconf:
-    #     test_handlerconf(main_logger)
-
+    if throttle:
+        test_throttle(main_logger)
+    if handlertypes:
+        test_handlertypes(main_logger)
+    if handlerconf:
+        test_handlerconf(main_logger)
+    if fallback_handlers:
+        test_fallback_handlers(log_level)
+    if ershandlers:
+        test_ers_handler_configuration(log_level)
 
 if __name__ == "__main__":
     main()

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -10,9 +10,11 @@ from daqpytools.logging.formatter import CONTEXT_SETTINGS
 from daqpytools.logging.handlers import (
     HandlerType,
     LogHandlerConf,
+    add_stdout_handler,
 )
+
 from daqpytools.logging.levels import logging_log_level_keys
-from daqpytools.logging.logger import get_daq_logger
+from daqpytools.logging.logger import get_daq_logger, setup_daq_ers_logger
 from daqpytools.logging.utils import get_width
 
 
@@ -402,25 +404,61 @@ def main(
     """
     logger_name = "daqpytools_logging_demonstrator"
 
-    os.environ["DUNEDAQ_ERS_WARNING"] = "erstrace,throttle,lstdout"
-    os.environ["DUNEDAQ_ERS_INFO"] = "lstderr,throttle,lstdout"
-    os.environ["DUNEDAQ_ERS_FATAL"] = "rich,lstdout"
+    os.environ["DUNEDAQ_ERS_WARNING"] = "erstrace,throttle,lstderr"
+    os.environ["DUNEDAQ_ERS_INFO"] = "lstderr,throttle,lstderr"
+    os.environ["DUNEDAQ_ERS_FATAL"] = "lstderr"
     os.environ["DUNEDAQ_ERS_ERROR"] = (
         "erstrace,"
         "throttle,"
-        "lstdout,"
+        "lstderr,"
         "protobufstream(monkafka.cern.ch:30092)"
     )
+
+    handlerconf = LogHandlerConf(init_ers=True)
 
     main_logger: logging.Logger = get_daq_logger(
         logger_name=logger_name,
         log_level=log_level,
-        rich_handler=False,
-        setup_ers_handlers=True,
-        ers_kafka_handler="session_temp"
+        stream_handlers=False,
+        rich_handler=True # only rich was defined
     )
 
-    main_logger.warning("test")
+    main_logger.warning("Only Rich")
+
+    # add_stdout_handler(main_logger, True)
+    setup_daq_ers_logger(main_logger, "session_temp")
+
+    main_logger.critical("Should be only rich")
+
+
+    # main_logger.critical("test") #use only rich because we only iniitlaise with rich
+
+    main_logger.critical("Stream", extra={"handlers": [HandlerType.Stream]})
+
+    
+    
+    main_logger.critical("ERS (lstderr only)", extra=handlerconf.ERS)
+
+    
+
+
+
+    # define a default handlerconf so for example 
+
+
+    """
+    Concrete suggestions
+
+    For now:
+    get_daq_logger = rich_handler = True  # save rich_handler and set as base class
+
+    setup_ers(log) #adds stream handler and what have you
+    
+    log.warning("something") # only goes to rich because we only initialise with rich
+
+    log.warning("something else", extra= ers) # use whatever is in ers
+    
+    """
 
 
     # main_logger: logging.Logger = get_daq_logger(

--- a/src/daqpytools/apps/logging_demonstrator.py
+++ b/src/daqpytools/apps/logging_demonstrator.py
@@ -401,36 +401,58 @@ def main(
         LoggerSetupError: If no handlers are set up for the logger.
     """
     logger_name = "daqpytools_logging_demonstrator"
+
+    os.environ["DUNEDAQ_ERS_WARNING"] = "erstrace,throttle,lstdout"
+    os.environ["DUNEDAQ_ERS_INFO"] = "lstderr,throttle,lstdout"
+    os.environ["DUNEDAQ_ERS_FATAL"] = "rich,lstdout"
+    os.environ["DUNEDAQ_ERS_ERROR"] = (
+        "erstrace,"
+        "throttle,"
+        "lstdout,"
+        "protobufstream(monkafka.cern.ch:30092)"
+    )
+
     main_logger: logging.Logger = get_daq_logger(
         logger_name=logger_name,
         log_level=log_level,
-        use_parent_handlers=not disable_logger_inheritance,
-        rich_handler=rich_handler,
-        file_handler_path=file_handler_path,
-        stream_handlers=stream_handlers,
-        ers_kafka_handler=ersprotobufstream,
-        throttle=throttle
+        rich_handler=False,
+        setup_ers_handlers=True,
+        ers_kafka_handler="session_temp"
     )
 
-    if not suppress_basic:
-        test_main_functions(main_logger)
-    
-    if child_logger: 
-        test_child_logger(
-            logger_name,
-            log_level,
-            disable_logger_inheritance,
-            rich_handler,
-            file_handler_path,
-            stream_handlers
-        )
+    main_logger.warning("test")
 
-    if throttle:
-        test_throttle(main_logger)
-    if handlertypes:
-        test_handlertypes(main_logger)
-    if handlerconf:
-        test_handlerconf(main_logger)
+
+    # main_logger: logging.Logger = get_daq_logger(
+    #     logger_name=logger_name,
+    #     log_level=log_level,
+    #     use_parent_handlers=not disable_logger_inheritance,
+    #     rich_handler=rich_handler,
+    #     file_handler_path=file_handler_path,
+    #     stream_handlers=stream_handlers,
+    #     ers_kafka_handler=ersprotobufstream,
+    #     throttle=throttle
+    # )
+
+    # if not suppress_basic:
+    #     test_main_functions(main_logger)
+    
+    # if child_logger: 
+    #     test_child_logger(
+    #         logger_name,
+    #         log_level,
+    #         disable_logger_inheritance,
+    #         rich_handler,
+    #         file_handler_path,
+    #         stream_handlers
+    #     )
+
+    # if throttle:
+    #     test_throttle(main_logger)
+    # if handlertypes:
+    #     test_handlertypes(main_logger)
+    # if handlerconf:
+    #     test_handlerconf(main_logger)
 
 
 if __name__ == "__main__":

--- a/src/daqpytools/logging/__init__.py
+++ b/src/daqpytools/logging/__init__.py
@@ -1,0 +1,14 @@
+from daqpytools.logging.levels import logging_log_levels
+from daqpytools.logging.handlerconf import LogHandlerConf, HandlerType
+from daqpytools.logging.logger import setup_daq_ers_logger, get_daq_logger, setup_root_logger
+from daqpytools.logging.handlers import add_handler
+
+__all__ = [
+    "logging_log_levels",
+    "LogHandlerConf",
+    "HandlerType",
+    "setup_daq_ers_logger",
+    "get_daq_logger",
+    "setup_root_logger",
+    "add_handler",
+]

--- a/src/daqpytools/logging/__init__.py
+++ b/src/daqpytools/logging/__init__.py
@@ -1,14 +1,18 @@
-from daqpytools.logging.levels import logging_log_levels
-from daqpytools.logging.handlerconf import LogHandlerConf, HandlerType
-from daqpytools.logging.logger import setup_daq_ers_logger, get_daq_logger, setup_root_logger
+from daqpytools.logging.handlerconf import HandlerType, LogHandlerConf
 from daqpytools.logging.handlers import add_handler
+from daqpytools.logging.levels import logging_log_levels
+from daqpytools.logging.logger import (
+    get_daq_logger,
+    setup_daq_ers_logger,
+    setup_root_logger,
+)
 
 __all__ = [
-    "logging_log_levels",
-    "LogHandlerConf",
     "HandlerType",
-    "setup_daq_ers_logger",
-    "get_daq_logger",
-    "setup_root_logger",
+    "LogHandlerConf",
     "add_handler",
+    "get_daq_logger",
+    "logging_log_levels",
+    "setup_daq_ers_logger",
+    "setup_root_logger",
 ]

--- a/src/daqpytools/logging/exceptions.py
+++ b/src/daqpytools/logging/exceptions.py
@@ -44,6 +44,15 @@ class ERSEnvError(Exception):
         super().__init__(err_msg)
 
 
+class ERSInitError(Exception):
+    """Custom error for ERS Init."""
+
+    def __init__(self, address:str, topic:str) -> None:
+        """C'tor."""
+        err_msg = f"The Kafka broker cannot be initialised using {address=} and {topic=}"
+        super().__init__(err_msg)
+
+
 
 class ProtobufFormatError(Exception):
     """Custom error for Protobuf URL formatting issues."""

--- a/src/daqpytools/logging/exceptions.py
+++ b/src/daqpytools/logging/exceptions.py
@@ -49,7 +49,10 @@ class ERSInitError(Exception):
 
     def __init__(self, address:str, topic:str) -> None:
         """C'tor."""
-        err_msg = f"The Kafka broker cannot be initialised using {address=} and {topic=}"
+        err_msg = (
+            "The Kafka broker cannot be initialised using "
+            f"{address=} and {topic=}"
+        )
         super().__init__(err_msg)
 
 

--- a/src/daqpytools/logging/filters.py
+++ b/src/daqpytools/logging/filters.py
@@ -272,9 +272,10 @@ def _build_throttle_filter(
     )
 
 THROTTLE_FILTER_SPEC = FilterSpec(
-    representative_type = HandlerType.Throttle,
-    filter_type = ThrottleFilter,
-    factory=_build_throttle_filter
+    alias = HandlerType.Throttle,
+    filter_class = ThrottleFilter,
+    factory=_build_throttle_filter,
+    fallback_types=(HandlerType.Throttle,),
 )
 
 FILTER_SPEC_REGISTRY: dict[HandlerType, FilterSpec] = {
@@ -294,7 +295,7 @@ def add_filter(
     spec = get_filter_spec(handler_type)
 
     logger_filter = spec.factory(
-        fallback_handlers if fallback_handlers is not None else spec.filter_handler_ids,
+        fallback_handlers if fallback_handlers is not None else set(spec.fallback_types),
         **extras
     )
     log.addFilter(logger_filter)

--- a/src/daqpytools/logging/filters.py
+++ b/src/daqpytools/logging/filters.py
@@ -19,7 +19,6 @@ from daqpytools.logging.formatter import (
 from daqpytools.logging.handlerconf import (
     HandlerType,
     LogHandlerConf,
-    _resolve_default_case,
 )
 from daqpytools.logging.routing import (
     AllowedHandlersStrategy,
@@ -294,7 +293,10 @@ def add_filter(
     """Add a logger filter according to the spec"""
     spec = get_filter_spec(handler_type)
 
-    logger_filter = spec.factory(_resolve_default_case(fallback_handlers), extras or {})
+    logger_filter = spec.factory(
+        fallback_handlers if fallback_handlers is not None else spec.filter_handler_ids,
+        extras
+    )
     log.addFilter(logger_filter)
 
 

--- a/src/daqpytools/logging/filters.py
+++ b/src/daqpytools/logging/filters.py
@@ -4,10 +4,9 @@ import copy
 import logging
 import time
 from collections import defaultdict
-from collections.abc import Mapping
 from datetime import datetime
 from threading import Lock
-from typing import Any, cast
+from typing import Any
 
 from rich.text import Text
 
@@ -260,11 +259,12 @@ class ThrottleFilter(BaseHandlerFilter):
 
 def _build_throttle_filter(
     fallback_handlers: set[HandlerType],
-    extras: Mapping[str, Any],
+    initial_treshold : int = 30,
+    time_limit: int = 30,
+    **extras: Any,
 ) -> logging.Filter:
     """Build throttle filter from extras"""
-    initial_treshold = cast(int, extras.get("initial_treshold", 30))
-    time_limit = cast(int, extras.get("time_limit", 30))
+    del extras
     return ThrottleFilter(
         fallback_handlers=fallback_handlers,
         initial_threshold=initial_treshold,
@@ -288,14 +288,14 @@ def add_filter(
     log: logging.Logger,
     handler_type:HandlerType,
     fallback_handlers : set[HandlerType]| None,
-    extras: Mapping[str,Any] | None = None,
+    **extras: Any,
 ) -> None:
     """Add a logger filter according to the spec"""
     spec = get_filter_spec(handler_type)
 
     logger_filter = spec.factory(
         fallback_handlers if fallback_handlers is not None else spec.filter_handler_ids,
-        extras
+        **extras
     )
     log.addFilter(logger_filter)
 

--- a/src/daqpytools/logging/filters.py
+++ b/src/daqpytools/logging/filters.py
@@ -1,42 +1,31 @@
 from __future__ import annotations
 
 import copy
-import io
 import logging
-import sys
 import time
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Mapping
 from datetime import datetime
 from threading import Lock
-from typing import cast, Mapping, Any
+from typing import Any, cast
 
-from erskafka.ERSKafkaLogHandler import ERSKafkaLogHandler
-from rich.logging import RichHandler
 from rich.text import Text
 
-from daqpytools.logging.exceptions import (
-    LoggerHandlerError,
-)
 from daqpytools.logging.formatter import (
     DATE_TIME_BASE_FORMAT,
     LOG_RECORD_PADDING,
     TIME_ZONE,
-    LoggingFormatter,
 )
-from daqpytools.logging.rich_handler import FormattedRichHandler
-from daqpytools.logging.specs import HandlerSpec, FilterSpec
-
-from daqpytools.logging.handlerdataclasses import (
+from daqpytools.logging.handlerconf import (
     HandlerType,
     LogHandlerConf,
-    _resolve_default_case
+    _resolve_default_case,
 )
 from daqpytools.logging.routing import (
     AllowedHandlersStrategy,
     StreamAwareAllowedHandlersStrategy,
 )
-from daqpytools.logging.utils import get_width
+from daqpytools.logging.specs import FilterSpec
 
 
 class IssueRecord:
@@ -291,7 +280,6 @@ THROTTLE_FILTER_SPEC = FilterSpec(
 
 FILTER_SPEC_REGISTRY: dict[HandlerType, FilterSpec] = {
     HandlerType.Throttle: THROTTLE_FILTER_SPEC
-
 }
 
 def get_filter_spec(handler_types: HandlerType):
@@ -314,7 +302,7 @@ def add_throttle_filter(
     log: logging.Logger,
     fallback_handlers: set[HandlerType] | None = None,
 ) -> None:
-    "Add the Throttle filter to the logger"
+    """Add the Throttle filter to the logger"""
     add_filter(
         log,
         HandlerType.Throttle,

--- a/src/daqpytools/logging/filters.py
+++ b/src/daqpytools/logging/filters.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import copy
+import io
+import logging
+import sys
+import time
+from collections import defaultdict
+from collections.abc import Callable
+from datetime import datetime
+from threading import Lock
+from typing import cast, Mapping, Any
+
+from erskafka.ERSKafkaLogHandler import ERSKafkaLogHandler
+from rich.logging import RichHandler
+from rich.text import Text
+
+from daqpytools.logging.exceptions import (
+    LoggerHandlerError,
+)
+from daqpytools.logging.formatter import (
+    DATE_TIME_BASE_FORMAT,
+    LOG_RECORD_PADDING,
+    TIME_ZONE,
+    LoggingFormatter,
+)
+from daqpytools.logging.rich_handler import FormattedRichHandler
+from daqpytools.logging.specs import HandlerSpec, FilterSpec
+
+from daqpytools.logging.handlerdataclasses import (
+    HandlerType,
+    LogHandlerConf,
+    _resolve_default_case
+)
+from daqpytools.logging.routing import (
+    AllowedHandlersStrategy,
+    StreamAwareAllowedHandlersStrategy,
+)
+from daqpytools.logging.utils import get_width
+
+
+class IssueRecord:
+    """Tracks throttling state for a unique issue (identified by file: line)."""
+    
+    def __init__(self) -> None:
+        """C'tor."""
+        self.reset()
+    
+    def reset(self) -> None:
+        """Reset all counters and timestamps."""
+        self.last_occurrence:  float = 0.0
+        self.last_report: float = 0.0
+        self.initial_counter: int = 0
+        self.threshold:  int = 10
+        self.suppressed_counter: int = 0
+        self.last_occurrence_formatted: str = ""
+
+class BaseHandlerFilter(logging.Filter):
+    """Base filter that hold the logic on choosing if a handler should emit
+    based on what HandlersTypes are supplied to it.
+    """
+    def __init__(
+        self,
+        fallback_handlers: set[HandlerType] | None = None,
+        allowed_handlers_strategy : AllowedHandlersStrategy | None = None,
+    ) -> None:
+        """C'tor."""
+        self.fallback_handlers = set(fallback_handlers) if fallback_handlers is not None else LogHandlerConf.get_base() #! We should check if this is still the case
+
+        self.allowed_handlers_strategy = (
+            allowed_handlers_strategy or 
+            StreamAwareAllowedHandlersStrategy()
+        )
+        super().__init__()
+
+    def get_allowed(self, record: logging.LogRecord) -> set[HandlerType] | None:
+        return self.allowed_handlers_strategy.resolve(record, self.fallback_handlers)
+
+        
+class HandleIDFilter(BaseHandlerFilter):
+    """Filter class that accepts a list of 'allowed' handlers and will only fire
+    if the current handler (defined by the handler_id) is within the set of 
+    allowed handlers.
+    """
+    def __init__(
+        self,
+        handler_id: HandlerType | list[HandlerType],
+        fallback_handlers: set[HandlerType] | None = None,
+        allowed_handlers_strategy: AllowedHandlersStrategy | None = None,
+    ) -> None:
+        """Initialises HandleIDFilter with the handler_id, to identify what
+        kind of handler this filter is.
+        """
+        super().__init__(
+            fallback_handlers = fallback_handlers,
+            allowed_handlers_strategy=allowed_handlers_strategy
+        )
+        
+        # Normalise handler_id to be a set
+        if isinstance(handler_id, list):
+            self.handler_ids = set(handler_id)
+        else:
+            self.handler_ids = {handler_id}
+    
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Identifies when a log message should be transmitted or not."""
+        if not (allowed:= self.get_allowed(record)):
+            return False
+        return bool(self.handler_ids & allowed)
+
+class ThrottleFilter(BaseHandlerFilter):
+    """Advanced logging filter with escalating throttle thresholds.
+    
+    Args:
+        initial_threshold: Number of initial occurrences 
+            to let through immediately (default: 30)
+        time_limit: Time window in seconds for resetting state (default: 30)
+        name: Optional filter name
+    
+    Example:
+        >>> import logging
+        >>> logger = logging.getLogger(__name__)
+        >>> throttle = ThrottleFilter(initial_threshold=30, time_limit=30)
+        >>> logger.addFilter(throttle)
+        >>> handler = logging.StreamHandler()
+        >>> logger.addHandler(handler)
+        >>> logger.setLevel(logging. ERROR)
+        >>> 
+        >>> # First 30 messages go through immediately
+        >>> for i in range(100):
+        ...     logger.error("Repeated error message")
+    """
+    
+    def __init__(
+        self,
+        fallback_handlers: set[HandlerType] | None = None,
+        initial_threshold: int = 30,
+        time_limit: int = 30,
+        allowed_handlers_strategy : AllowedHandlersStrategy | None = None
+    ) -> None:
+        """C'tor."""
+        super().__init__(
+            fallback_handlers = fallback_handlers,
+            allowed_handlers_strategy = allowed_handlers_strategy
+            )
+        self.initial_threshold = initial_threshold
+        self.time_limit = time_limit
+        self.issue_map: dict[str, IssueRecord] = defaultdict(IssueRecord)
+        self.mutex = Lock() # Ensures thread safety
+    
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Determine if a log record should be emitted.
+        
+        Args:
+            record: The log record to filter
+            
+        Returns:
+            True if the record should be logged, False to suppress it
+        """
+        # Check if we want to apply the filter
+        if not (allowed:= self.get_allowed(record)):
+            return False
+        if HandlerType.Throttle not in allowed:
+            return True
+        
+        # Used to bypass the filter to report suppression messages
+        if getattr(record, '_throttle_suppression', False):
+            return True
+        
+        issue_id = f"{record.pathname}:{record.lineno}"
+        with self.mutex:
+            issue_record = self.issue_map[issue_id]
+            return self._throttle(issue_record, record)
+    
+    def _throttle(self, rec: IssueRecord, record:  logging.LogRecord) -> bool:
+        """Apply throttling logic to determine if record should be emitted.
+        
+        Args:
+            rec: The issue record tracking state for this unique issue
+            record: The log record being evaluated
+            
+        Returns:
+            True if record should be emitted, False otherwise
+        """
+        current_time = time.time()
+        reported = False
+        
+        # Step 1: Check if time window expired - reset if so
+        if current_time - rec.last_occurrence > self.time_limit:
+            if rec.suppressed_counter > 0:
+                self._report_suppression(rec, record)
+                reported = True
+            rec.reset()
+        
+        # Step 2: Initial phase - let first N messages through
+        if rec.initial_counter < self.initial_threshold:
+            rec.initial_counter += 1
+            rec.last_report = current_time
+            rec.last_occurrence = current_time
+            rec.last_occurrence_formatted = self._format_timestamp(current_time)
+            
+            # Don't double-report if we just reported suppression
+            return not reported
+        
+        # Step 3: Check if we hit the escalating threshold
+        if rec.suppressed_counter >= rec.threshold:
+            rec.threshold = rec.threshold * 10  # Escalate:  10 -> 100 -> 1000 ... 
+            rec.last_occurrence = current_time
+            rec. last_occurrence_formatted = self._format_timestamp(current_time)
+            self._report_suppression(rec, record)
+            return False  # Don't emit the original record
+        
+        # Step 4: Check if enough time passed since last report
+        if current_time - rec.last_report > self.time_limit:
+            rec.last_occurrence = current_time
+            rec. last_occurrence_formatted = self._format_timestamp(current_time)
+            self._report_suppression(rec, record)
+            return False  # Don't emit the original record
+        
+        # Step 5: Suppress silently
+        rec.suppressed_counter += 1
+        rec.last_occurrence = current_time
+        rec. last_occurrence_formatted = self._format_timestamp(current_time)
+        return False
+    
+    def _report_suppression(self, rec: IssueRecord, record: logging.LogRecord) -> None:
+        """Create and emit a suppression notice.
+        
+        Args:
+            rec: The issue record with suppression count
+            record: The original log record (used as template)
+        """
+        if rec.suppressed_counter == 0:
+            return
+        
+        suppression_record = copy.deepcopy(record)
+        suppression_record._throttle_suppression = True # pass through filter to report
+        
+        # Append suppression information to the message
+        suppression_msg = (
+            f" -- {rec.suppressed_counter} similar messages suppressed, "
+            f"last occurrence was at {rec.last_occurrence_formatted}"
+        )
+        suppression_record.msg = record.getMessage() + suppression_msg
+        suppression_record.args = ()  # Clear args since we already formatted
+        
+        # Emit directly - will pass through filter due to flag
+        logger = logging.getLogger(record.name)
+        logger.handle(suppression_record)
+
+        
+        # Reset suppression tracking
+        rec.last_report = time.time()
+        rec.suppressed_counter = 0
+    
+    @staticmethod
+    def _format_timestamp(timestamp: float) -> str:
+        """Format timestamp in ISO format with microseconds.
+        
+        Args:
+            timestamp: Unix timestamp
+            
+        Returns:
+            Formatted timestamp string
+        """
+        dt = datetime.fromtimestamp(timestamp, tz=TIME_ZONE)
+        padding: int = LOG_RECORD_PADDING.get("time", 25)
+        time_str: str = dt.strftime(DATE_TIME_BASE_FORMAT).ljust(padding)[:padding]
+        return Text(time_str, style="logging.time")
+  
+
+
+def _build_throttle_filter(
+    fallback_handlers: set[HandlerType],
+    extras: Mapping[str, Any],
+) -> logging.Filter:
+    """Build throttle filter from extras"""
+    initial_treshold = cast(int, extras.get("initial_treshold", 30))
+    time_limit = cast(int, extras.get("time_limit", 30))
+    return ThrottleFilter(
+        fallback_handlers=fallback_handlers,
+        initial_threshold=initial_treshold,
+        time_limit=time_limit
+    )
+
+THROTTLE_FILTER_SPEC = FilterSpec(
+    representative_type = HandlerType.Throttle,
+    filter_type = ThrottleFilter,
+    factory=_build_throttle_filter
+)
+
+FILTER_SPEC_REGISTRY: dict[HandlerType, FilterSpec] = {
+    HandlerType.Throttle: THROTTLE_FILTER_SPEC
+
+}
+
+def get_filter_spec(handler_types: HandlerType):
+    return FILTER_SPEC_REGISTRY.get(handler_types)
+
+def add_filter(
+    log: logging.Logger,
+    handler_type:HandlerType,
+    fallback_handlers : set[HandlerType]| None,
+    extras: Mapping[str,Any] | None = None,
+) -> None:
+    """Add a logger filter according to the spec"""
+    spec = get_filter_spec(handler_type)
+
+    logger_filter = spec.factory(_resolve_default_case(fallback_handlers), extras or {})
+    log.addFilter(logger_filter)
+
+
+def add_throttle_filter(
+    log: logging.Logger,
+    fallback_handlers: set[HandlerType] | None = None,
+) -> None:
+    "Add the Throttle filter to the logger"
+    add_filter(
+        log,
+        HandlerType.Throttle,
+        fallback_handlers
+    )

--- a/src/daqpytools/logging/filters.py
+++ b/src/daqpytools/logging/filters.py
@@ -6,7 +6,6 @@ import time
 from collections import defaultdict
 from datetime import datetime
 from threading import Lock
-from typing import Any
 
 from rich.text import Text
 
@@ -52,7 +51,11 @@ class BaseHandlerFilter(logging.Filter):
         allowed_handlers_strategy : AllowedHandlersStrategy | None = None,
     ) -> None:
         """C'tor."""
-        self.fallback_handlers = set(fallback_handlers) if fallback_handlers is not None else LogHandlerConf.get_base() #! We should check if this is still the case
+        self.fallback_handlers = (
+            set(fallback_handlers)
+            if fallback_handlers is not None
+            else LogHandlerConf.get_base()
+        )
 
         self.allowed_handlers_strategy = (
             allowed_handlers_strategy or 
@@ -61,6 +64,7 @@ class BaseHandlerFilter(logging.Filter):
         super().__init__()
 
     def get_allowed(self, record: logging.LogRecord) -> set[HandlerType] | None:
+        """Resolve the allowed handlers for a record."""
         return self.allowed_handlers_strategy.resolve(record, self.fallback_handlers)
 
         
@@ -261,9 +265,9 @@ def _build_throttle_filter(
     fallback_handlers: set[HandlerType],
     initial_treshold : int = 30,
     time_limit: int = 30,
-    **extras: Any,
+    **extras: object,
 ) -> logging.Filter:
-    """Build throttle filter from extras"""
+    """Build a throttle filter from extras."""
     del extras
     return ThrottleFilter(
         fallback_handlers=fallback_handlers,
@@ -282,20 +286,26 @@ FILTER_SPEC_REGISTRY: dict[HandlerType, FilterSpec] = {
     HandlerType.Throttle: THROTTLE_FILTER_SPEC
 }
 
-def get_filter_spec(handler_types: HandlerType):
+def get_filter_spec(handler_types: HandlerType) -> FilterSpec | None:
+    """Return the filter specification for a handler type."""
     return FILTER_SPEC_REGISTRY.get(handler_types)
 
 def add_filter(
     log: logging.Logger,
     handler_type:HandlerType,
     fallback_handlers : set[HandlerType]| None,
-    **extras: Any,
+    **extras: object,
 ) -> None:
-    """Add a logger filter according to the spec"""
+    """Add a logger filter according to the spec."""
     spec = get_filter_spec(handler_type)
 
+    effective_fallback_handlers = (
+        fallback_handlers
+        if fallback_handlers is not None
+        else set(spec.fallback_types)
+    )
     logger_filter = spec.factory(
-        fallback_handlers if fallback_handlers is not None else set(spec.fallback_types),
+        effective_fallback_handlers,
         **extras
     )
     log.addFilter(logger_filter)
@@ -305,7 +315,7 @@ def add_throttle_filter(
     log: logging.Logger,
     fallback_handlers: set[HandlerType] | None = None,
 ) -> None:
-    """Add the Throttle filter to the logger"""
+    """Add the Throttle filter to the logger."""
     add_filter(
         log,
         HandlerType.Throttle,

--- a/src/daqpytools/logging/formatter.py
+++ b/src/daqpytools/logging/formatter.py
@@ -2,6 +2,7 @@ import configparser
 import logging
 import os
 import re
+from copy import copy
 from datetime import datetime, tzinfo
 from pathlib import Path
 
@@ -107,18 +108,26 @@ class LoggingFormatter(logging.Formatter):
         * Component widths.
         * Removes markdown-style comments from the message.
         """
-        if isinstance(record.msg, str):
-            record.msg = re.sub(r"\[/?[^\]]+\]", "", record.msg)
+        formatted_record = copy(record)
 
-        record.asctime = self.formatTime(record, self.datefmt)
+        if isinstance(formatted_record.msg, str):
+            formatted_record.msg = re.sub(
+                r"\[/?[^\]]+\]", "", formatted_record.msg
+            )
+
+        formatted_record.asctime = self.formatTime(formatted_record, self.datefmt)
 
         padding = LOG_RECORD_PADDING.get("level", 10)
-        record.levelname = record.levelname.ljust(padding)[:padding]
+        formatted_record.levelname = formatted_record.levelname.ljust(padding)[:padding]
 
         padding = LOG_RECORD_PADDING.get("file_and_line", 40)
-        record.filename = f"{record.filename}:{record.lineno}".ljust(padding)[:padding]
+        formatted_record.filename = (
+            f"{formatted_record.filename}:{formatted_record.lineno}".ljust(padding)[
+                :padding
+            ]
+        )
 
         padding = LOG_RECORD_PADDING.get("logger_name", 40)
-        record.name = f"{record.name}".ljust(padding)[:padding]
+        formatted_record.name = f"{formatted_record.name}".ljust(padding)[:padding]
 
-        return super().format(record)
+        return super().format(formatted_record)

--- a/src/daqpytools/logging/handlerconf.py
+++ b/src/daqpytools/logging/handlerconf.py
@@ -189,8 +189,10 @@ class LogHandlerConf:
         protobufconf: ProtobufConf | None = None
 
         for raw_handler in envvalue.split(","):
-            handlertype, parsed_protobufconf = LogHandlerConf._convert_str_to_handlertype(
+            handlertype, parsed_protobufconf = (
+                LogHandlerConf._convert_str_to_handlertype(
                 raw_handler.strip()
+                )
             )
 
             if handlertype is not None:

--- a/src/daqpytools/logging/handlerconf.py
+++ b/src/daqpytools/logging/handlerconf.py
@@ -4,28 +4,16 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
 from enum import Enum
 from typing import ClassVar
-
-from rich.console import Console, ConsoleRenderable
-from rich.logging import RichHandler
-from rich.text import Text
 
 from daqpytools.logging.exceptions import (
     ERSEnvError,
     ProtobufFormatError,
 )
-from daqpytools.logging.formatter import (
-    CONSOLE_THEME,
-    DATE_TIME_FORMAT,
-    LOG_RECORD_PADDING,
-    TIME_ZONE,
-)
-from daqpytools.logging.levels import level_to_ers_var, logging_log_level_to_str
-from daqpytools.logging.utils import get_width
-
+from daqpytools.logging.levels import level_to_ers_var
 from daqpytools.logging.rich_handler import FormattedRichHandler
+from daqpytools.logging.utils import get_width
 
 # Initialise a logger to catch erstrace + other unknown handlertypes from OKS
 log: logging.Logger = logging.getLogger(__name__)
@@ -219,13 +207,3 @@ class LogHandlerConf:
         return set(LogHandlerConf._BASE_HANDLERS)
     
 
-
-
-#! This we should be careful with..
-def _resolve_default_case(
-    default_case: set[HandlerType] | None
-) -> set[HandlerType]:
-    "Return a safe copy of default_case with sensible fallback"
-    if default_case is None:
-        return LogHandlerConf.get_base()
-    return set(default_case)

--- a/src/daqpytools/logging/handlerconf.py
+++ b/src/daqpytools/logging/handlerconf.py
@@ -26,7 +26,7 @@ class StreamType(Enum):
     OPMON="opmon"
     ERS="ers"
 
-@dataclass 
+@dataclass(frozen=True)
 class ProtobufConf:
     """Dataclass to hold Protobuf Configuration."""
     url:str= "monkafka.cern.ch"
@@ -59,7 +59,7 @@ class HandlerType(Enum):
             log.warning(msg)
             return None
 
-@dataclass
+@dataclass(frozen=True)
 class ERSPyLogHandlerConf:
     """Dataclass that holds the relevant ERS configuration from OKS.
 
@@ -181,17 +181,28 @@ class LogHandlerConf:
     @staticmethod
     def _make_ers_handler_conf(ers_log_level :str) -> ERSPyLogHandlerConf:
         """Generates the ERSPyLogHandlerConf from reading an environment variable."""
-        erspyloghandlerconf = ERSPyLogHandlerConf()
         envvalue = os.getenv(ers_log_level)
         if envvalue is None:
             raise ERSEnvError(ers_log_level)
         
-        for h in envvalue.split(","):
-            handlertype, kafkaconf = LogHandlerConf._convert_str_to_handlertype(h)
-            erspyloghandlerconf.handlers.append(handlertype)
-            if kafkaconf:
-                erspyloghandlerconf.protobufconf = kafkaconf 
-        return erspyloghandlerconf
+        ers_handlers: list[HandlerType] = []
+        protobufconf: ProtobufConf | None = None
+
+        for raw_handler in envvalue.split(","):
+            handlertype, parsed_protobufconf = LogHandlerConf._convert_str_to_handlertype(
+                raw_handler.strip()
+            )
+
+            if handlertype is not None:
+                ers_handlers.append(handlertype)
+
+            if parsed_protobufconf is not None:
+                protobufconf = parsed_protobufconf
+        
+        return ERSPyLogHandlerConf(
+            handlers = ers_handlers,
+            protobufconf = protobufconf
+        )
 
     @staticmethod
     def _get_oks_conf() -> dict:

--- a/src/daqpytools/logging/handlerdataclasses.py
+++ b/src/daqpytools/logging/handlerdataclasses.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import ClassVar
+
+from rich.console import Console, ConsoleRenderable
+from rich.logging import RichHandler
+from rich.text import Text
+
+from daqpytools.logging.exceptions import (
+    ERSEnvError,
+    ProtobufFormatError,
+)
+from daqpytools.logging.formatter import (
+    CONSOLE_THEME,
+    DATE_TIME_FORMAT,
+    LOG_RECORD_PADDING,
+    TIME_ZONE,
+)
+from daqpytools.logging.levels import level_to_ers_var, logging_log_level_to_str
+from daqpytools.logging.utils import get_width
+
+
+class FormattedRichHandler(RichHandler):
+    """RichHandler that formats log messages with time, aligned columns, and styles."""
+
+    def __init__(self, width: int = 100) -> None:
+        """Initialize with custom console and style settings."""
+        console: Console = Console(
+            force_terminal=True, width=width, theme=CONSOLE_THEME
+        )
+        super().__init__(
+            console=console,
+            omit_repeated_times=False,
+            markup=True,
+            rich_tracebacks=True,
+            show_path=False,
+            show_time=False,  # We format time ourselves
+        )
+
+    def render(
+        self,
+        *,
+        record: logging.LogRecord,
+        traceback: object,
+        message_renderable: ConsoleRenderable,
+    ) -> Text:
+        """Render the log record into a rich Text object with custom formatting.
+
+        Args:
+            record (logging.LogRecord): The log record to render.
+            traceback (object): The traceback object (not used here).
+            message_renderable (ConsoleRenderable): The log message renderable.
+
+        Returns:
+            Text: The formatted log record as a rich Text object.
+
+        Raises:
+            None
+        """
+        dt: datetime = datetime.fromtimestamp(record.created, tz=TIME_ZONE)
+        padding: int = LOG_RECORD_PADDING.get("time", 25)
+        time_str: str = dt.strftime(DATE_TIME_FORMAT).ljust(padding)[:padding]
+        time_text: Text = Text(time_str, style="logging.time")
+
+        padding = LOG_RECORD_PADDING.get("level", 10)
+        level_text: Text = Text(
+            record.levelname.ljust(padding)[:padding],
+            style=self._get_level_style(record.levelno),
+        )
+
+        file_and_no: str = f"{record.filename}:{record.lineno}"
+        padding = LOG_RECORD_PADDING.get("file_and_line", 40)
+        file_and_no_text: Text = Text(
+            file_and_no.ljust(padding)[:padding], style="logging.location"
+        )
+
+        padding = LOG_RECORD_PADDING.get("logger_name", 45)
+        logger_name_text: Text = Text(
+            f"{record.name}".ljust(padding)[:padding], style="logging.logger_name"
+        )
+
+        # Convert message_renderable to Text for type consistency
+        message_text: Text
+        if isinstance(message_renderable, Text):
+            message_text = message_renderable
+        else:
+            message_text = Text.from_markup(str(message_renderable))
+
+        components: list[Text] = [
+            time_text,
+            level_text,
+            file_and_no_text,
+            logger_name_text,
+            message_text,
+        ]
+
+        return Text(" ").join(components)
+
+    def _get_level_style(self, level_no: int) -> str:
+        """Get the style string for the given log level number from the theme defined in
+        CONSOLE_THEME.
+
+        Args:
+            level_no (int): The log level number.
+
+        Returns:
+            str: The style string for the log level.
+        """
+        return str(
+            CONSOLE_THEME.styles.get(
+                f"logging.level.{logging_log_level_to_str(level_no).lower()}", ""
+            )
+        )
+
+
+
+# Initialise a logger to catch erstrace + other unknown handlertypes from OKS
+log: logging.Logger = logging.getLogger(__name__)
+log.addHandler(FormattedRichHandler(width=get_width()))
+log.setLevel("INFO")
+
+class StreamType(Enum):
+    """Enumtype to classify the set of relevant handlers (i.e streams)."""
+    BASE="base"
+    OPMON="opmon"
+    ERS="ers"
+
+@dataclass 
+class ProtobufConf:
+    """Dataclass to hold Protobuf Configuration."""
+    url:str= "monkafka.cern.ch"
+    port:int= 30092
+
+    def get_string(self) -> str:
+        """Converts back to string version."""
+        return f"{self.url}:{self.port}"
+
+class HandlerType(Enum):
+    """Enumtype to classify the existing set of Handlers.
+    Values must match exactly what is given in the OKS configuration, if any
+    All are in lowercase.
+    """
+    Unknown = "unknown"
+    Stream = "stream"
+    Rich = "rich"
+    File = "file"
+    Protobufstream = "protobufstream"
+    Lstdout = "lstdout"
+    Lstderr = "lstderr"
+    Throttle = "throttle"
+    @classmethod
+    def from_string(cls, s: str) -> HandlerType | None:
+        """Converts from a case-independent string to HandlerType."""
+        try:
+            return HandlerType(s.lower())
+        except ValueError:
+            msg=f"[red]{s}[/red] is not a known handler type"
+            log.warning(msg)
+            return None
+
+@dataclass
+class ERSPyLogHandlerConf:
+    """Dataclass that holds the relevant ERS configuration from OKS.
+
+    As an example, given the following
+    <obj class="Variable" id="ehn1-env-ers-error">
+        <attr name="name" type="string" val="DUNEDAQ_ERS_ERROR"/>
+        <attr name="value" type="string" val="erstrace,throttle,lstdout,
+            protobufstream(monkafka.cern.ch:30092)"/>
+    </obj>
+
+    This dataclass holds the list of relevant Handlers attached to the ERS log level. 
+    In case it also contains a single protobuf handler, the configuration is stored by 
+    the ProtobufConf instance. Multiple protobuf handlers with different url/ports 
+    are not yet supported.
+    """
+    handlers: list = field(default_factory = lambda: [])
+    protobufconf: ProtobufConf = field(default_factory = lambda: None)
+
+
+@dataclass
+class LogHandlerConf:
+    """Dataclass that holds the various streams and relevant handlers.
+    
+    Attributes:
+        init_ers: If True, automatically initializes ERS configuration 
+            during construction.
+        _BASE_HANDLERS: Private class variable for default base handlers
+        _OPMON_HANDLERS: Private class variable for opmon handlers
+        BASE_CONFIG: Class variable for base stream configuration
+        OPMON_CONFIG: Class variable for opmon stream configuration
+        ERS: Instance field for ERS configuration (loaded from environment)
+    """
+    init_ers: bool = False
+
+    _BASE_HANDLERS: ClassVar[set] = {HandlerType.Stream, HandlerType.Rich,
+        HandlerType.File
+        }
+    _OPMON_HANDLERS: ClassVar[set] = {HandlerType.Rich, HandlerType.Stream,
+        HandlerType.File}
+    _ERS: object = None
+    
+    Base: ClassVar[dict] = {
+        "handlers": _BASE_HANDLERS,
+        "stream": StreamType.BASE
+    }
+    
+    Opmon: ClassVar[dict] = {
+        "handlers": _OPMON_HANDLERS,
+        "stream": StreamType.OPMON
+    }
+
+    def __post_init__(self) -> None:
+        """Initialize ERS configuration if init_ers field is True.
+
+        This method is called automatically after dataclass initialization.
+        If the init_ers attribute was set to True, it triggers the complete
+        ERS initialization.
+        """
+        if self.init_ers:
+            self.init_ers_stream()
+
+    @property
+    def ERS(self) -> dict : # noqa: N802
+        """Get the ERS configuration dictionary.
+        
+        Returns:
+            dict: Contains 'ers_handlers' and 'stream' configuration for ERS
+            
+        Raises:
+            AttributeError: If ERS has not been
+                initialized (call init_ers_stream() first)
+        """
+        if not self._ERS:
+            err_msg = "ERS stream not initialised. Call init_ers_stream() first"
+            raise AttributeError(err_msg)
+        return self._ERS
+
+    def init_ers_stream(self) -> None:
+        """Initialize ERS configuration from environment variables.
+        
+        Loads ERS configuration from OKS environment variables and populates
+        the _ERS dict with handlers and stream information.
+        
+        Called automatically during construction if init_ers=True, or can be
+        called manually afterwards.
+        """
+        self._ERS = {
+            "ers_handlers":  LogHandlerConf._get_oks_conf(),
+            "stream": StreamType.ERS
+        }   
+
+    @staticmethod
+    def _convert_str_to_handlertype(handler_str: str) -> tuple[HandlerType,
+        ProtobufConf | None]:
+        """Parses a given environment variable to obtain the
+        HandlerType and ProtobufConf as necessary. 
+
+        Eg. converts "throttle" to HandlerType.Throttle
+            converts "protobufstream(url:port)" to return both the HandlerType and the 
+            protobuf configuration
+        """
+        if "erstrace" in handler_str:
+            msg = (
+                "ERSTrace is a C++ implementation, "
+                "does not have an equivalent in Python"
+            )
+            log.debug(msg)
+            return None, None
+
+        if HandlerType.Protobufstream.value not in handler_str:
+            return HandlerType.from_string(handler_str), None
+
+        match = re.search(r"\(([^:]+):(\d+)\)", handler_str)
+        if not match:
+            raise ProtobufFormatError(handler_str)
+        url, port = match.group(1), int(match.group(2))
+        return HandlerType.Protobufstream, ProtobufConf(url=url, port=port)
+
+    @staticmethod
+    def _make_ers_handler_conf(ers_log_level :str) -> ERSPyLogHandlerConf:
+        """Generates the ERSPyLogHandlerConf from reading an environment variable."""
+        erspyloghandlerconf = ERSPyLogHandlerConf()
+        envvalue = os.getenv(ers_log_level)
+        if envvalue is None:
+            raise ERSEnvError(ers_log_level)
+        
+        for h in envvalue.split(","):
+            handlertype, kafkaconf = LogHandlerConf._convert_str_to_handlertype(h)
+            erspyloghandlerconf.handlers.append(handlertype)
+            if kafkaconf:
+                erspyloghandlerconf.protobufconf = kafkaconf 
+        return erspyloghandlerconf
+
+    @staticmethod
+    def _get_oks_conf() -> dict:
+        """From the set of known environment variables, generate the ERS conf dict."""
+        return {var: LogHandlerConf._make_ers_handler_conf(var) 
+            for var in list(level_to_ers_var.values())}
+    
+    @staticmethod
+    def get_base() -> set[HandlerType]:
+        """Returns the default list of handlers from
+        LogHandlerConf._BASE_HANDLERS without having to initialise an instance.
+        """
+        return LogHandlerConf._BASE_HANDLERS

--- a/src/daqpytools/logging/handlerdataclasses.py
+++ b/src/daqpytools/logging/handlerdataclasses.py
@@ -217,3 +217,15 @@ class LogHandlerConf:
         LogHandlerConf._BASE_HANDLERS without having to initialise an instance.
         """
         return set(LogHandlerConf._BASE_HANDLERS)
+    
+
+
+
+#! This we should be careful with..
+def _resolve_default_case(
+    default_case: set[HandlerType] | None
+) -> set[HandlerType]:
+    "Return a safe copy of default_case with sensible fallback"
+    if default_case is None:
+        return LogHandlerConf.get_base()
+    return set(default_case)

--- a/src/daqpytools/logging/handlerdataclasses.py
+++ b/src/daqpytools/logging/handlerdataclasses.py
@@ -25,100 +25,7 @@ from daqpytools.logging.formatter import (
 from daqpytools.logging.levels import level_to_ers_var, logging_log_level_to_str
 from daqpytools.logging.utils import get_width
 
-
-class FormattedRichHandler(RichHandler):
-    """RichHandler that formats log messages with time, aligned columns, and styles."""
-
-    def __init__(self, width: int = 100) -> None:
-        """Initialize with custom console and style settings."""
-        console: Console = Console(
-            force_terminal=True, width=width, theme=CONSOLE_THEME
-        )
-        super().__init__(
-            console=console,
-            omit_repeated_times=False,
-            markup=True,
-            rich_tracebacks=True,
-            show_path=False,
-            show_time=False,  # We format time ourselves
-        )
-
-    def render(
-        self,
-        *,
-        record: logging.LogRecord,
-        traceback: object,
-        message_renderable: ConsoleRenderable,
-    ) -> Text:
-        """Render the log record into a rich Text object with custom formatting.
-
-        Args:
-            record (logging.LogRecord): The log record to render.
-            traceback (object): The traceback object (not used here).
-            message_renderable (ConsoleRenderable): The log message renderable.
-
-        Returns:
-            Text: The formatted log record as a rich Text object.
-
-        Raises:
-            None
-        """
-        dt: datetime = datetime.fromtimestamp(record.created, tz=TIME_ZONE)
-        padding: int = LOG_RECORD_PADDING.get("time", 25)
-        time_str: str = dt.strftime(DATE_TIME_FORMAT).ljust(padding)[:padding]
-        time_text: Text = Text(time_str, style="logging.time")
-
-        padding = LOG_RECORD_PADDING.get("level", 10)
-        level_text: Text = Text(
-            record.levelname.ljust(padding)[:padding],
-            style=self._get_level_style(record.levelno),
-        )
-
-        file_and_no: str = f"{record.filename}:{record.lineno}"
-        padding = LOG_RECORD_PADDING.get("file_and_line", 40)
-        file_and_no_text: Text = Text(
-            file_and_no.ljust(padding)[:padding], style="logging.location"
-        )
-
-        padding = LOG_RECORD_PADDING.get("logger_name", 45)
-        logger_name_text: Text = Text(
-            f"{record.name}".ljust(padding)[:padding], style="logging.logger_name"
-        )
-
-        # Convert message_renderable to Text for type consistency
-        message_text: Text
-        if isinstance(message_renderable, Text):
-            message_text = message_renderable
-        else:
-            message_text = Text.from_markup(str(message_renderable))
-
-        components: list[Text] = [
-            time_text,
-            level_text,
-            file_and_no_text,
-            logger_name_text,
-            message_text,
-        ]
-
-        return Text(" ").join(components)
-
-    def _get_level_style(self, level_no: int) -> str:
-        """Get the style string for the given log level number from the theme defined in
-        CONSOLE_THEME.
-
-        Args:
-            level_no (int): The log level number.
-
-        Returns:
-            str: The style string for the log level.
-        """
-        return str(
-            CONSOLE_THEME.styles.get(
-                f"logging.level.{logging_log_level_to_str(level_no).lower()}", ""
-            )
-        )
-
-
+from daqpytools.logging.rich_handler import FormattedRichHandler
 
 # Initialise a logger to catch erstrace + other unknown handlertypes from OKS
 log: logging.Logger = logging.getLogger(__name__)
@@ -309,4 +216,4 @@ class LogHandlerConf:
         """Returns the default list of handlers from
         LogHandlerConf._BASE_HANDLERS without having to initialise an instance.
         """
-        return LogHandlerConf._BASE_HANDLERS
+        return set(LogHandlerConf._BASE_HANDLERS)

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import logging
 import sys
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import Any, cast
 
 from erskafka.ERSKafkaLogHandler import ERSKafkaLogHandler
@@ -13,7 +13,8 @@ from daqpytools.logging.exceptions import (
 )
 from daqpytools.logging.filters import (
     HandleIDFilter,
-    ThrottleFilter,
+    add_filter,
+    get_filter_spec,
 )
 from daqpytools.logging.formatter import (
     LoggingFormatter,
@@ -254,9 +255,18 @@ def add_handler(
     fallback_handler: set[HandlerType] | None,
     extras: Mapping[str, Any] | None = None,
 ):
-    
     specs = get_handler_specs(handler_type) 
     for spec in specs:
+        if logger_or_ancestors_have_handler(
+            log,
+            use_parent_handlers,
+            spec.handler_type,
+            target_stream=spec.target_stream,
+        ):
+            # raise ValueError('HEY THEY ALREADY EXIST')
+            continue
+            
+
         check_parent_handlers(
             log,
             use_parent_handlers,
@@ -360,117 +370,36 @@ def add_ers_kafka_handler(
         },
     )
     
-from daqpytools.logging.filters import add_throttle_filter
-
-
-#! This is the big ol massive function.. we should refactor this
 def add_handlers_from_types(
     log: logging.Logger,
     handler_types: set[HandlerType],
     use_parent_handlers: bool,
     fallback_handlers: set[HandlerType],
-    file_name: str | None,
-    ers_kafka_session: str | None,
-    app_name : str|None = None,
+    extras: Mapping[str, Any] | None = None,
 ) -> None:
-    """Add handlers to a logger based on a set of HandlerType values.
+    """Add handlers and filters from a set of HandlerType values.
 
-    This helper intentionally supports only the default options for now:
-    - ``use_parent_handlers`` is always True.
-    - ``HandlerType.File`` is not supported and raises immediately.
-    - ``HandlerType.Protobufstream`` requires ``ers_kafka_session``.
+    Handler types resolve through ``HANDLER_SPEC_REGISTRY`` and are installed
+    using ``add_handler``. Filter types resolve through ``FILTER_SPEC_REGISTRY``
+    and are installed using ``add_filter``.
     """
-    if HandlerType.Protobufstream in handler_types and not ers_kafka_session:
-        err_msg = "ers_kafka_session is required for HandlerType.Protobufstream"
-        raise ValueError(err_msg)
-    
-    if HandlerType.File in handler_types and not file_name:
-        err_msg = "file_name is required for HandlerType.File"
-        raise ValueError(err_msg)
-
-    # Update relevant handler types that was parsed
     effective_handler_types = set(handler_types)
+
     if HandlerType.Stream in effective_handler_types:
-        effective_handler_types.update({HandlerType.Lstdout, HandlerType.Lstderr})
+        effective_handler_types.discard(HandlerType.Lstdout)
+        effective_handler_types.discard(HandlerType.Lstderr)
 
-    # Generate handler configurations based on arguments for auto install
-    handler_configs: dict[
-        HandlerType,
-        tuple[
-            type[logging.Handler] | None, # Handler as seen by Python's Logger
-            io.IOBase | None, # Used for streamhandling
-            type[logging.Filter] | None, # For filters attached to loggers
-            Callable[[], None],  # Installer code
-        ],
-    ] = {
-        HandlerType.Rich: (
-            FormattedRichHandler,
-            None,
-            None,
-            lambda: add_rich_handler(log, use_parent_handlers, fallback_handlers),
-        ),
-        HandlerType.Lstdout: (
-            logging.StreamHandler,
-            cast(io.IOBase, sys.stdout),
-            None,
-            lambda: add_stdout_handler(log, use_parent_handlers, fallback_handlers),
-        ),
-        HandlerType.Lstderr: (
-            logging.StreamHandler,
-            cast(io.IOBase, sys.stderr),
-            None,
-            lambda: add_stderr_handler(log, use_parent_handlers, fallback_handlers),
-        ),
-        HandlerType.Protobufstream: (
-            ERSKafkaLogHandler,
-            None,
-            None,
-            lambda: add_ers_kafka_handler(
-                log, use_parent_handlers, ers_kafka_session, {HandlerType.Unknown},
-                app_name
-                # WE DONT WANT TO TRANSMIT BY DEFAULT
-            ),
-        ),
-        HandlerType.Throttle: (
-            None,
-            None,
-            ThrottleFilter,
-            lambda: add_throttle_filter(log, fallback_handlers),
-        ),
-        HandlerType.File: (
-            logging.FileHandler,
-            None,
-            None,
-            lambda: add_file_handler(
-                log, use_parent_handlers, file_name, fallback_handlers
-            ),
-        ),
-    }
-
-
-    for handler_type, (
-        handler_class,
-        target_stream,
-        filter_type,
-        installer,
-    ) in handler_configs.items():
-        
-        # Skips if it encounters an unrequested handler
-        if handler_type not in effective_handler_types:
-            continue
-        
-        # Skips if handler/filter exists in either the logger or any of its ancestors
-        handler_exists = (
-            handler_class is not None
-            and logger_or_ancestors_have_handler(
+    for handler_type in effective_handler_types:
+        if get_handler_specs(handler_type):
+            add_handler(
                 log,
+                handler_type,
                 use_parent_handlers,
-                handler_class,
-                target_stream=target_stream,
+                fallback_handlers,
+                extras,
             )
-        ) or (filter_type is not None and logger_has_filter(log, filter_type))
-        
-        if handler_exists:
             continue
-        
-        installer()
+
+        filter_spec = get_filter_spec(handler_type)
+        if filter_spec and not logger_has_filter(log, filter_spec.filter_type):
+            add_filter(log, handler_type, fallback_handlers, extras)

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -738,6 +738,7 @@ def add_ers_kafka_handler(
     use_parent_handlers: bool,
     session_name: str,
     fallback_handlers: set[HandlerType] | None = None,
+    app_name : str|None =None,
     topic: str = "ers_stream",
     address: str = "monkafka.cern.ch:30092",
 ) -> None:
@@ -748,7 +749,8 @@ def add_ers_kafka_handler(
     check_parent_handlers(log, use_parent_handlers, ERSKafkaLogHandler)
     handler: ERSKafkaLogHandler = ERSKafkaLogHandler(session=session_name, 
                                                      kafka_address = address, 
-                                                     kafka_topic = topic
+                                                     kafka_topic = topic,
+                                                     app_name = app_name,
                                                      )
 
     handler.addFilter(
@@ -880,19 +882,20 @@ def add_handlers_from_types(
     log: logging.Logger,
     handler_types: set[HandlerType],
     use_parent_handlers: bool,
-    file_name: str | None,
-    ers_session_name: str | None,
     fallback_handlers: set[HandlerType],
+    file_name: str | None,
+    ers_kafka_session: str | None,
+    app_name : str|None = None,
 ) -> None:
     """Add handlers to a logger based on a set of HandlerType values.
 
     This helper intentionally supports only the default options for now:
     - ``use_parent_handlers`` is always True.
     - ``HandlerType.File`` is not supported and raises immediately.
-    - ``HandlerType.Protobufstream`` requires ``ers_session_name``.
+    - ``HandlerType.Protobufstream`` requires ``ers_kafka_session``.
     """
-    if HandlerType.Protobufstream in handler_types and not ers_session_name:
-        err_msg = "ers_session_name is required for HandlerType.Protobufstream"
+    if HandlerType.Protobufstream in handler_types and not ers_kafka_session:
+        err_msg = "ers_kafka_session is required for HandlerType.Protobufstream"
         raise ValueError(err_msg)
     
     if HandlerType.File in handler_types and not file_name:
@@ -937,7 +940,8 @@ def add_handlers_from_types(
             None,
             None,
             lambda: add_ers_kafka_handler(
-                log, use_parent_handlers, ers_session_name, {HandlerType.Unknown}
+                log, use_parent_handlers, ers_kafka_session, {HandlerType.Unknown},
+                app_name
                 # WE DONT WANT TO TRANSMIT BY DEFAULT
             ),
         ),

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -1,53 +1,32 @@
 from __future__ import annotations
 
-import copy
 import io
 import logging
 import sys
-import time
-from collections import defaultdict
-from collections.abc import Callable
-from datetime import datetime
-from threading import Lock
-from typing import cast, Mapping, Any
+from collections.abc import Callable, Mapping
+from typing import Any, cast
 
 from erskafka.ERSKafkaLogHandler import ERSKafkaLogHandler
-from rich.logging import RichHandler
-from rich.text import Text
 
 from daqpytools.logging.exceptions import (
     LoggerHandlerError,
 )
-from daqpytools.logging.formatter import (
-    DATE_TIME_BASE_FORMAT,
-    LOG_RECORD_PADDING,
-    TIME_ZONE,
-    LoggingFormatter,
-)
-
 from daqpytools.logging.filters import (
-    IssueRecord,
-    BaseHandlerFilter,
     HandleIDFilter,
     ThrottleFilter,
 )
-
-from daqpytools.logging.rich_handler import FormattedRichHandler
-from daqpytools.logging.specs import HandlerSpec, FilterSpec
-
-from daqpytools.logging.handlerdataclasses import (
+from daqpytools.logging.formatter import (
+    LoggingFormatter,
+)
+from daqpytools.logging.handlerconf import (
     HandlerType,
-    LogHandlerConf,
-    _resolve_default_case
 )
-from daqpytools.logging.routing import (
-    AllowedHandlersStrategy,
-    StreamAwareAllowedHandlersStrategy,
-)
+from daqpytools.logging.rich_handler import FormattedRichHandler
+from daqpytools.logging.specs import HandlerSpec
 from daqpytools.logging.utils import get_width
 
 
-  
+#### Helper functions ####
 def logger_has_handler(
     log: logging.Logger,
     handler_type: type[logging.Handler],
@@ -156,7 +135,6 @@ def check_parent_handlers(
     if ancestors_have_handlers(log, use_parent_handlers, handler_type, target_stream):
         raise LoggerHandlerError(log.name, handler_type)
     
-
 def logger_or_ancestors_have_handler(
     log: logging.Logger,
     use_parent_handlers: bool,
@@ -169,6 +147,8 @@ def logger_or_ancestors_have_handler(
     ) or ancestors_have_handlers(log, use_parent_handlers, handler_type, target_stream)
 
 
+#### Handlers #### 
+
 def _build_rich_handler(extras: Mapping[str, Any]) -> logging.Handler:
     """Building the rich handler with any extras."""
     width = cast(int,  extras.get("width", get_width()))
@@ -180,7 +160,6 @@ RICH_HANDLER_SPEC = HandlerSpec(
     factory=_build_rich_handler,
     filter_handler_ids = (HandlerType.Rich,), # For HandleIDFilter
 )
-
 
 def _build_stdout_handler(extras: Mapping[str, Any]) -> logging.Handler:
     del extras #unused
@@ -196,14 +175,12 @@ STDOUT_HANDLER_SPEC = HandlerSpec(
     filter_handler_ids = (HandlerType.Stream, HandlerType.Lstdout),
 )
 
-
 def _build_stderr_handler(extras: Mapping[str, Any]) -> logging.Handler:
     del extras #unused
     handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(LoggingFormatter())
     handler.setLevel(logging.ERROR)
     return handler
-
 
 STDERR_HANDLER_SPEC = HandlerSpec(
     representative_type = HandlerType.Lstderr,
@@ -212,8 +189,6 @@ STDERR_HANDLER_SPEC = HandlerSpec(
     factory=_build_stderr_handler,
     filter_handler_ids = (HandlerType.Stream, HandlerType.Lstderr),
 )
-
-
 
 def _build_file_handler(extras: Mapping[str, Any]) -> logging.Handler:
     path = cast(str | None, extras.get("path"))
@@ -232,8 +207,6 @@ FILE_HANDLER_SPEC = HandlerSpec(
     filter_handler_ids=(HandlerType.File,)
 )
 
-
-
 def _build_erskafka_handler(extras: Mapping[str, Any]) -> logging.Handler: 
     session_name = cast( str | None, extras.get("session_name"))
 
@@ -251,8 +224,6 @@ def _build_erskafka_handler(extras: Mapping[str, Any]) -> logging.Handler:
         app_name=app_name
     )
     
-
-
 ERSKAFKA_HANDLER_SPEC = HandlerSpec(
     representative_type=HandlerType.Protobufstream,
     handler_type = ERSKafkaLogHandler,
@@ -275,9 +246,6 @@ HANDLER_SPEC_REGISTRY : dict[HandlerType, tuple[HandlerSpec, ...]] = {
 def get_handler_specs(handler_type: HandlerType):
     """Get the specs defined in the registry"""
     return HANDLER_SPEC_REGISTRY.get(handler_type, tuple())
-
-
-
 
 def add_handler(
     log: logging.Logger,
@@ -315,8 +283,8 @@ def add_handler(
         log.addHandler(handler)
 
 
-# We want to eventually depreciate this I think..
-# In favour of add_handlers_or_filters
+#! Backwards compatibility. We should consider retiring these functinos
+
 def add_rich_handler(
     log: logging.Logger,
     use_parent_handlers: bool,
@@ -330,7 +298,6 @@ def add_rich_handler(
         fallback_handlers
     )
 
-
 def add_stdout_handler(
     log: logging.Logger,
     use_parent_handlers: bool,
@@ -342,7 +309,6 @@ def add_stdout_handler(
         use_parent_handlers,
         fallback_handlers
     )
-
 
 def add_stderr_handler(
     log: logging.Logger,
@@ -394,84 +360,10 @@ def add_ers_kafka_handler(
         },
     )
     
-
 from daqpytools.logging.filters import add_throttle_filter
 
-##################################################################################################
-##################################################################################################
-##################################################################################################
-##################################################################################################
-##################################################################################################
 
-
-
-# def add_ers_kafka_handler(
-#     log: logging.Logger,
-#     use_parent_handlers: bool,
-#     session_name: str,
-#     fallback_handlers: set[HandlerType] | None = None,
-#     app_name : str|None =None,
-#     topic: str = "ers_stream",
-#     address: str = "monkafka.cern.ch:30092",
-# ) -> None:
-#     # TODO/future: topic and address are new, propagate to all relevant implementation
-#     """Add an ers protobuf handler to the root logger."""
-#     if fallback_handlers is None:
-#         fallback_handlers = {HandlerType.Protobufstream}
-#     check_parent_handlers(log, use_parent_handlers, ERSKafkaLogHandler)
-#     handler: ERSKafkaLogHandler = ERSKafkaLogHandler(session=session_name, 
-#                                                      kafka_address = address, 
-#                                                      kafka_topic = topic,
-#                                                      app_name = app_name,
-#                                                      )
-
-#     handler.addFilter(
-#         HandleIDFilter(
-#             handler_id=HandlerType.Protobufstream,
-#             fallback_handlers=fallback_handlers
-#             )
-#     )
-#     log.addHandler(handler)
-
-# def add_file_handler(
-#     log: logging.Logger,
-#     use_parent_handlers: bool,
-#     path: str,
-#     fallback_handlers: set[HandlerType] | None = None,
-# ) -> None:
-#     """Add a file handler to the root logger.
-
-#     Args:
-#         log (logging.Logger): Logger to add the file handler to.
-#         use_parent_handlers (bool): Whether to check parent handlers.
-#         path (str): Path to the log file.
-#         fallback_handlers (set[HandlerType] | None): Default handler set used when
-#             records do not explicitly include handler routing.
-
-#     Returns:
-#         None
-
-#     Raises:
-#         LoggerHandlerError: If a parent logger has a file handler.
-#     """
-#     if fallback_handlers is None:
-#         fallback_handlers = {HandlerType.File}
-#     check_parent_handlers(log, use_parent_handlers, logging.FileHandler)
-#     file_handler = logging.FileHandler(filename=path)
-#     file_handler.setFormatter(LoggingFormatter())
-#     file_handler.addFilter(
-#         HandleIDFilter(
-#             handler_id=HandlerType.File,
-#             fallback_handlers=fallback_handlers
-#             )
-#     )
-#     log.addHandler(file_handler)
-#     return
-
-
-
-
-# This is the big ol massive function..
+#! This is the big ol massive function.. we should refactor this
 def add_handlers_from_types(
     log: logging.Logger,
     handler_types: set[HandlerType],

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -9,6 +9,7 @@ from erskafka.ERSKafkaLogHandler import ERSKafkaLogHandler
 
 from daqpytools.logging.exceptions import (
     LoggerHandlerError,
+    ERSInitError
 )
 from daqpytools.logging.filters import (
     HandleIDFilter,
@@ -210,13 +211,17 @@ def _build_erskafka_handler(
         address : str = "monkafka.cern.ch:30092",
         ers_app_name : str | None = None,
         **_) -> logging.Handler: 
+    
+    try:
+        return ERSKafkaLogHandler(
+            session = session_name,
+            kafka_address=address,
+            kafka_topic = topic,
+            app_name=ers_app_name
+        )
+    except:
+        raise ERSInitError(address, topic)
 
-    return ERSKafkaLogHandler(
-        session = session_name,
-        kafka_address=address,
-        kafka_topic = topic,
-        app_name=ers_app_name
-    )
     
 ERSKAFKA_HANDLER_SPEC = HandlerSpec(
     representative_type=HandlerType.Protobufstream,

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -25,12 +25,20 @@ from daqpytools.logging.formatter import (
     LoggingFormatter,
 )
 
+from daqpytools.logging.filters import (
+    IssueRecord,
+    BaseHandlerFilter,
+    HandleIDFilter,
+    ThrottleFilter,
+)
+
 from daqpytools.logging.rich_handler import FormattedRichHandler
 from daqpytools.logging.specs import HandlerSpec, FilterSpec
 
 from daqpytools.logging.handlerdataclasses import (
     HandlerType,
     LogHandlerConf,
+    _resolve_default_case
 )
 from daqpytools.logging.routing import (
     AllowedHandlersStrategy,
@@ -39,235 +47,7 @@ from daqpytools.logging.routing import (
 from daqpytools.logging.utils import get_width
 
 
-class IssueRecord:
-    """Tracks throttling state for a unique issue (identified by file: line)."""
-    
-    def __init__(self) -> None:
-        """C'tor."""
-        self.reset()
-    
-    def reset(self) -> None:
-        """Reset all counters and timestamps."""
-        self.last_occurrence:  float = 0.0
-        self.last_report: float = 0.0
-        self.initial_counter: int = 0
-        self.threshold:  int = 10
-        self.suppressed_counter: int = 0
-        self.last_occurrence_formatted: str = ""
-
-class BaseHandlerFilter(logging.Filter):
-    """Base filter that hold the logic on choosing if a handler should emit
-    based on what HandlersTypes are supplied to it.
-    """
-    def __init__(
-        self,
-        fallback_handlers: set[HandlerType] | None = None,
-        allowed_handlers_strategy : AllowedHandlersStrategy | None = None,
-    ) -> None:
-        """C'tor."""
-        self.fallback_handlers = set(fallback_handlers) if fallback_handlers is not None else LogHandlerConf.get_base() #! We should check if this is still the case
-
-        self.allowed_handlers_strategy = (
-            allowed_handlers_strategy or 
-            StreamAwareAllowedHandlersStrategy()
-        )
-        super().__init__()
-
-    def get_allowed(self, record: logging.LogRecord) -> set[HandlerType] | None:
-        return self.allowed_handlers_strategy.resolve(record, self.fallback_handlers)
-
-        
-class HandleIDFilter(BaseHandlerFilter):
-    """Filter class that accepts a list of 'allowed' handlers and will only fire
-    if the current handler (defined by the handler_id) is within the set of 
-    allowed handlers.
-    """
-    def __init__(
-        self,
-        handler_id: HandlerType | list[HandlerType],
-        fallback_handlers: set[HandlerType] | None = None,
-        allowed_handlers_strategy: AllowedHandlersStrategy | None = None,
-    ) -> None:
-        """Initialises HandleIDFilter with the handler_id, to identify what
-        kind of handler this filter is.
-        """
-        super().__init__(
-            fallback_handlers = fallback_handlers,
-            allowed_handlers_strategy=allowed_handlers_strategy
-        )
-        
-        # Normalise handler_id to be a set
-        if isinstance(handler_id, list):
-            self.handler_ids = set(handler_id)
-        else:
-            self.handler_ids = {handler_id}
-    
-    def filter(self, record: logging.LogRecord) -> bool:
-        """Identifies when a log message should be transmitted or not."""
-        if not (allowed:= self.get_allowed(record)):
-            return False
-        return bool(self.handler_ids & allowed)
-
-class ThrottleFilter(BaseHandlerFilter):
-    """Advanced logging filter with escalating throttle thresholds.
-    
-    Args:
-        initial_threshold: Number of initial occurrences 
-            to let through immediately (default: 30)
-        time_limit: Time window in seconds for resetting state (default: 30)
-        name: Optional filter name
-    
-    Example:
-        >>> import logging
-        >>> logger = logging.getLogger(__name__)
-        >>> throttle = ThrottleFilter(initial_threshold=30, time_limit=30)
-        >>> logger.addFilter(throttle)
-        >>> handler = logging.StreamHandler()
-        >>> logger.addHandler(handler)
-        >>> logger.setLevel(logging. ERROR)
-        >>> 
-        >>> # First 30 messages go through immediately
-        >>> for i in range(100):
-        ...     logger.error("Repeated error message")
-    """
-    
-    def __init__(
-        self,
-        fallback_handlers: set[HandlerType] | None = None,
-        initial_threshold: int = 30,
-        time_limit: int = 30,
-        allowed_handlers_strategy : AllowedHandlersStrategy | None = None
-    ) -> None:
-        """C'tor."""
-        super().__init__(
-            fallback_handlers = fallback_handlers,
-            allowed_handlers_strategy = allowed_handlers_strategy
-            )
-        self.initial_threshold = initial_threshold
-        self.time_limit = time_limit
-        self.issue_map: dict[str, IssueRecord] = defaultdict(IssueRecord)
-        self.mutex = Lock() # Ensures thread safety
-    
-    def filter(self, record: logging.LogRecord) -> bool:
-        """Determine if a log record should be emitted.
-        
-        Args:
-            record: The log record to filter
-            
-        Returns:
-            True if the record should be logged, False to suppress it
-        """
-        # Check if we want to apply the filter
-        if not (allowed:= self.get_allowed(record)):
-            return False
-        if HandlerType.Throttle not in allowed:
-            return True
-        
-        # Used to bypass the filter to report suppression messages
-        if getattr(record, '_throttle_suppression', False):
-            return True
-        
-        issue_id = f"{record.pathname}:{record.lineno}"
-        with self.mutex:
-            issue_record = self.issue_map[issue_id]
-            return self._throttle(issue_record, record)
-    
-    def _throttle(self, rec: IssueRecord, record:  logging.LogRecord) -> bool:
-        """Apply throttling logic to determine if record should be emitted.
-        
-        Args:
-            rec: The issue record tracking state for this unique issue
-            record: The log record being evaluated
-            
-        Returns:
-            True if record should be emitted, False otherwise
-        """
-        current_time = time.time()
-        reported = False
-        
-        # Step 1: Check if time window expired - reset if so
-        if current_time - rec.last_occurrence > self.time_limit:
-            if rec.suppressed_counter > 0:
-                self._report_suppression(rec, record)
-                reported = True
-            rec.reset()
-        
-        # Step 2: Initial phase - let first N messages through
-        if rec.initial_counter < self.initial_threshold:
-            rec.initial_counter += 1
-            rec.last_report = current_time
-            rec.last_occurrence = current_time
-            rec.last_occurrence_formatted = self._format_timestamp(current_time)
-            
-            # Don't double-report if we just reported suppression
-            return not reported
-        
-        # Step 3: Check if we hit the escalating threshold
-        if rec.suppressed_counter >= rec.threshold:
-            rec.threshold = rec.threshold * 10  # Escalate:  10 -> 100 -> 1000 ... 
-            rec.last_occurrence = current_time
-            rec. last_occurrence_formatted = self._format_timestamp(current_time)
-            self._report_suppression(rec, record)
-            return False  # Don't emit the original record
-        
-        # Step 4: Check if enough time passed since last report
-        if current_time - rec.last_report > self.time_limit:
-            rec.last_occurrence = current_time
-            rec. last_occurrence_formatted = self._format_timestamp(current_time)
-            self._report_suppression(rec, record)
-            return False  # Don't emit the original record
-        
-        # Step 5: Suppress silently
-        rec.suppressed_counter += 1
-        rec.last_occurrence = current_time
-        rec. last_occurrence_formatted = self._format_timestamp(current_time)
-        return False
-    
-    def _report_suppression(self, rec: IssueRecord, record: logging.LogRecord) -> None:
-        """Create and emit a suppression notice.
-        
-        Args:
-            rec: The issue record with suppression count
-            record: The original log record (used as template)
-        """
-        if rec.suppressed_counter == 0:
-            return
-        
-        suppression_record = copy.deepcopy(record)
-        suppression_record._throttle_suppression = True # pass through filter to report
-        
-        # Append suppression information to the message
-        suppression_msg = (
-            f" -- {rec.suppressed_counter} similar messages suppressed, "
-            f"last occurrence was at {rec.last_occurrence_formatted}"
-        )
-        suppression_record.msg = record.getMessage() + suppression_msg
-        suppression_record.args = ()  # Clear args since we already formatted
-        
-        # Emit directly - will pass through filter due to flag
-        logger = logging.getLogger(record.name)
-        logger.handle(suppression_record)
-
-        
-        # Reset suppression tracking
-        rec.last_report = time.time()
-        rec.suppressed_counter = 0
-    
-    @staticmethod
-    def _format_timestamp(timestamp: float) -> str:
-        """Format timestamp in ISO format with microseconds.
-        
-        Args:
-            timestamp: Unix timestamp
-            
-        Returns:
-            Formatted timestamp string
-        """
-        dt = datetime.fromtimestamp(timestamp, tz=TIME_ZONE)
-        padding: int = LOG_RECORD_PADDING.get("time", 25)
-        time_str: str = dt.strftime(DATE_TIME_BASE_FORMAT).ljust(padding)[:padding]
-        return Text(time_str, style="logging.time")
-    
+  
 def logger_has_handler(
     log: logging.Logger,
     handler_type: type[logging.Handler],
@@ -394,7 +174,6 @@ def _build_rich_handler(extras: Mapping[str, Any]) -> logging.Handler:
     width = cast(int,  extras.get("width", get_width()))
     return FormattedRichHandler(width=width)
 
-
 RICH_HANDLER_SPEC = HandlerSpec(
     representative_type = HandlerType.Rich,
     handler_type = FormattedRichHandler,
@@ -402,59 +181,94 @@ RICH_HANDLER_SPEC = HandlerSpec(
     filter_handler_ids = (HandlerType.Rich,), # For HandleIDFilter
 )
 
+
+def _build_stdout_handler(extras: Mapping[str, Any]) -> logging.Handler:
+    del extras #unused
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(LoggingFormatter())
+    return handler
+
+STDOUT_HANDLER_SPEC = HandlerSpec(
+    representative_type = HandlerType.Lstdout,
+    handler_type = logging.StreamHandler,
+    target_stream=cast(io.IOBase, sys.stdout),
+    factory=_build_stdout_handler,
+    filter_handler_ids = (HandlerType.Stream, HandlerType.Lstdout),
+)
+
+
+def _build_stderr_handler(extras: Mapping[str, Any]) -> logging.Handler:
+    del extras #unused
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(LoggingFormatter())
+    handler.setLevel(logging.ERROR)
+    return handler
+
+
+STDERR_HANDLER_SPEC = HandlerSpec(
+    representative_type = HandlerType.Lstderr,
+    handler_type = logging.StreamHandler,
+    target_stream=cast(io.IOBase, sys.stderr),
+    factory=_build_stderr_handler,
+    filter_handler_ids = (HandlerType.Stream, HandlerType.Lstderr),
+)
+
+
+
 HANDLER_SPEC_REGISTRY : dict[HandlerType, tuple[HandlerSpec, ...]] = {
     HandlerType.Rich: (RICH_HANDLER_SPEC,),
+    HandlerType.Lstdout: (STDOUT_HANDLER_SPEC,),
+    HandlerType.Lstderr: (STDERR_HANDLER_SPEC,),
+    HandlerType.Stream: (STDOUT_HANDLER_SPEC,STDERR_HANDLER_SPEC),
+    
+    # Try stream next
 }
-
-#! Lets try go tet the add rich handler thing running!
-
 
 def get_handler_specs(handler_type: HandlerType):
     """Get the specs defined in the registry"""
     return HANDLER_SPEC_REGISTRY.get(handler_type, tuple())
 
 
-#! This we should be careful with..
-def _resolve_default_case(
-    default_case: set[HandlerType] | None
-) -> set[HandlerType]:
-    "Return a safe copy of default_case with sensible fallback"
-    if default_case is None:
-        return LogHandlerConf.get_base()
-    return set(default_case)
+
 
 def add_handler(
-    log: logging.logger_has_filter,
-    spec: HandlerSpec,
+    log: logging.Logger,
+    handler_type: HandlerType,
     use_parent_handlers:bool, 
     fallback_handler: set[HandlerType] | None,
     extras: Mapping[str, Any] | None = None,
 ):
-    check_parent_handlers(
-        log,
-        use_parent_handlers,
-        spec.handler_type,
-        target_stream = spec.target_stream
-    )
-
-    handler = spec.factory(extras or {})
-    effective_default_case = _resolve_default_case(fallback_handler)
-
-    handler_ids: HandlerType | list[HandlerType]
-    if len(spec.filter_handler_ids) == 1:
-        handler_ids = cast(HandlerType, spec.filter_handler_ids[0])
-    else: 
-        handler_ids = [cast(HandlerType, handler_id) for handler_id in spec.filter_handler_ids] 
-
-    handler.addFilter(
-        HandleIDFilter(
-            handler_id=handler_ids,
-            fallback_handlers=effective_default_case
+    
+    specs = get_handler_specs(handler_type) 
+    for spec in specs:
+        check_parent_handlers(
+            log,
+            use_parent_handlers,
+            spec.handler_type,
+            target_stream = spec.target_stream
         )
-    )
 
-    log.addHandler(handler)
+        handler = spec.factory(extras or {})
+        effective_default_case = fallback_handler if fallback_handler is not None else spec.filter_handler_ids
 
+        handler_ids: HandlerType | list[HandlerType]
+        if len(spec.filter_handler_ids) == 1:
+            handler_ids = cast(HandlerType, spec.filter_handler_ids[0])
+        else: 
+            handler_ids = [cast(HandlerType, handler_id) for handler_id in spec.filter_handler_ids] 
+ 
+        handler.addFilter(
+            HandleIDFilter(
+                handler_id=handler_ids,
+                fallback_handlers=effective_default_case
+            )
+        )
+
+        log.addHandler(handler)
+
+
+# We want to eventually depreciate this I think..
+# In favour of add_handlers_or_filters
 def add_rich_handler(
     log: logging.Logger,
     use_parent_handlers: bool,
@@ -463,124 +277,46 @@ def add_rich_handler(
     
     add_handler(
         log,
-        RICH_HANDLER_SPEC,
+        HandlerType.Rich,
         use_parent_handlers,
         fallback_handlers
     )
 
 
-def _build_throttle_filter(
-    fallback_handlers: set[HandlerType],
-    extras: Mapping[str, Any],
-) -> logging.Filter:
-    """Build throttle filter from extras"""
-    initial_treshold = cast(int, extras.get("initial_treshold", 30))
-    time_limit = cast(int, extras.get("time_limit", 30))
-    return ThrottleFilter(
-        fallback_handlers=fallback_handlers,
-        initial_threshold=initial_treshold,
-        time_limit=time_limit
-    )
-
-THROTTLE_FILTER_SPEC = FilterSpec(
-    representative_type = HandlerType.Throttle,
-    filter_type = ThrottleFilter,
-    factory=_build_throttle_filter
-)
-
-FILTER_SPEC_REGISTRY: dict[HandlerType, FilterSpec] = {
-    HandlerType.Throttle: THROTTLE_FILTER_SPEC
-
-}
-
-def get_filter_spec(handler_types: HandlerType):
-    return FILTER_SPEC_REGISTRY.get(handler_types)
-
-def add_filter(
+def add_stdout_handler(
     log: logging.Logger,
-    spec: FilterSpec,
-    fallback_handlers : set[HandlerType]| None,
-    extras: Mapping[str,Any] | None = None,
-) -> None:
-    """Add a logger filter according to the spec"""
-    logger_filter = spec.factory(_resolve_default_case(fallback_handlers), extras or {})
-    log.addFilter(logger_filter)
-
-
-def add_throttle_filter(
-    log: logging.Logger,
+    use_parent_handlers: bool,
     fallback_handlers: set[HandlerType] | None = None,
 ) -> None:
-    "Add the Throttle filter to the logger"
-    add_filter(
+    add_handler(
         log,
-        THROTTLE_FILTER_SPEC,
+        HandlerType.Lstdout,
+        use_parent_handlers,
         fallback_handlers
     )
 
 
-# figureo ut how this mattches to the add_handlers bit, this is very important!
-
-
-##################################################################################################
-##################################################################################################
-##################################################################################################
-##################################################################################################
-##################################################################################################
-
-
-def add_throttle_filter(
+def add_stderr_handler(
     log: logging.Logger,
+    use_parent_handlers: bool,
     fallback_handlers: set[HandlerType] | None = None,
 ) -> None:
-    """Add the Throttle filter to the logger.
+    add_handler(
+        log,
+        HandlerType.Lstderr,
+        use_parent_handlers,
+        fallback_handlers
+    )
 
-    Args:
-        log (logging.Logger): Logger to add the rich handler to.
-        fallback_handlers (set[HandlerType] | None): Default handler set used when
-            records do not explicitly include handler routing.
+from daqpytools.logging.filters import add_throttle_filter
 
-    Returns:
-        None
-    """
-    if fallback_handlers is None:
-        fallback_handlers = {HandlerType.Throttle}
-    log.addFilter(ThrottleFilter(fallback_handlers=fallback_handlers))
-    return
+##################################################################################################
+##################################################################################################
+##################################################################################################
+##################################################################################################
+##################################################################################################
 
-# def add_rich_handler(
-#     log: logging.Logger,
-#     use_parent_handlers: bool,
-#     fallback_handlers: set[HandlerType] | None = None,
-# ) -> None:
-#     """Add a rich handler to the logger.
 
-#     Args:
-#         log (logging.Logger): Logger to add the rich handler to.
-#         use_parent_handlers (bool): Whether to check parent handlers.
-#         fallback_handlers (set[HandlerType] | None): Default handler set used when
-#             records do not explicitly include handler routing.
-
-#     Returns:
-#         None
-
-#     Raises:
-#         LoggerHandlerError: If a parent logger has a rich handler.
-#     """
-#     if fallback_handlers is None:
-#         fallback_handlers = {HandlerType.Rich}
-#     check_parent_handlers(log, use_parent_handlers, FormattedRichHandler)
-#     width: int = get_width()
-#     handler: RichHandler = FormattedRichHandler(width=width)    
-    
-#     handler.addFilter(
-#         HandleIDFilter(
-#             handler_id=HandlerType.Rich,
-#             fallback_handlers=fallback_handlers
-#             )
-#     )
-#     log.addHandler(handler)
-#     return
 
 def add_ers_kafka_handler(
     log: logging.Logger,
@@ -610,87 +346,89 @@ def add_ers_kafka_handler(
     )
     log.addHandler(handler)
 
-def add_stdout_handler(
-    log: logging.Logger,
-    use_parent_handlers: bool,
-    fallback_handlers: set[HandlerType] | None = None,
-) -> None:
-    """Add a stdout handler to the logger.
+# def add_stdout_handler(
+#     log: logging.Logger,
+#     use_parent_handlers: bool,
+#     fallback_handlers: set[HandlerType] | None = None,
+# ) -> None:
+#     """Add a stdout handler to the logger.
 
-    Args:
-        log (logging.Logger): Logger to add the stdout handler to.
-        use_parent_handlers (bool): Whether to check parent handlers.
-        fallback_handlers (set[HandlerType] | None): Default handler set used when
-            records do not explicitly include handler routing.
+#     Args:
+#         log (logging.Logger): Logger to add the stdout handler to.
+#         use_parent_handlers (bool): Whether to check parent handlers.
+#         fallback_handlers (set[HandlerType] | None): Default handler set used when
+#             records do not explicitly include handler routing.
 
-    Returns:
-        None
+#     Returns:
+#         None
 
-    Raises:
-        LoggerHandlerError: If a parent logger has a stdout handler.
-    """
-    if fallback_handlers is None:
-        fallback_handlers = {HandlerType.Stream, HandlerType.Lstdout}
-    check_parent_handlers(
-        log,
-        use_parent_handlers,
-        logging.StreamHandler,
-        target_stream=cast(io.IOBase, sys.stdout),
-    )
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setFormatter(LoggingFormatter())
+#     Raises:
+#         LoggerHandlerError: If a parent logger has a stdout handler.
+#     """
+#     if fallback_handlers is None:
+#         fallback_handlers = {HandlerType.Stream, HandlerType.Lstdout}
+#     check_parent_handlers(
+#         log,
+#         use_parent_handlers,
+#         logging.StreamHandler,
+#         target_stream=cast(io.IOBase, sys.stdout),
+#     )
+#     stdout_handler = logging.StreamHandler(sys.stdout)
+#     stdout_handler.setFormatter(LoggingFormatter())
     
-    stdout_handler.addFilter(
-        HandleIDFilter(
-            handler_id=[HandlerType.Stream, HandlerType.Lstdout],
-            fallback_handlers=fallback_handlers
-            )
-    )    
-    log.addHandler(stdout_handler)
-    return
+#     stdout_handler.addFilter(
+#         HandleIDFilter(
+#             handler_id=[HandlerType.Stream, HandlerType.Lstdout],
+#             fallback_handlers=fallback_handlers
+#             )
+#     )    
+#     log.addHandler(stdout_handler)
+#     return
 
-def add_stderr_handler(
-    log: logging.Logger,
-    use_parent_handlers: bool,
-    fallback_handlers: set[HandlerType] | None = None,
-) -> None:
-    """Add a stderr handler to the logger.
+# def add_stderr_handler(
+#     log: logging.Logger,
+#     use_parent_handlers: bool,
+#     fallback_handlers: set[HandlerType] | None = None,
+# ) -> None:
+#     """Add a stderr handler to the logger.
 
-    The error is set to the ERROR level, and will only log messages at that level
-    or higher. This is to avoid duplicate logging of error messages when both stdout
-    and stderr handlers are used.
+#     The error is set to the ERROR level, and will only log messages at that level
+#     or higher. This is to avoid duplicate logging of error messages when both stdout
+#     and stderr handlers are used.
 
-    Args:
-        log (logging.Logger): Logger to add the stderr handler to.
-        use_parent_handlers (bool): Whether to check parent handlers.
-        fallback_handlers (set[HandlerType] | None): Default handler set used when
-            records do not explicitly include handler routing.
+#     Args:
+#         log (logging.Logger): Logger to add the stderr handler to.
+#         use_parent_handlers (bool): Whether to check parent handlers.
+#         fallback_handlers (set[HandlerType] | None): Default handler set used when
+#             records do not explicitly include handler routing.
 
-    Returns:
-        None
+#     Returns:
+#         None
 
-    Raises:
-        LoggerHandlerError: If a parent logger has a stderr handler.
-    """
-    if fallback_handlers is None:
-        fallback_handlers = {HandlerType.Lstderr, HandlerType.Stream}
-    check_parent_handlers(
-        log,
-        use_parent_handlers,
-        logging.StreamHandler,
-        target_stream=cast(io.IOBase, sys.stderr),
-    )
-    stderr_handler = logging.StreamHandler(sys.stderr)
-    stderr_handler.setFormatter(LoggingFormatter())
-    stderr_handler.addFilter(
-        HandleIDFilter(
-            handler_id=[HandlerType.Stream, HandlerType.Lstderr],
-            fallback_handlers=fallback_handlers
-            )
-    )    
-    stderr_handler.setLevel(logging.ERROR)
-    log.addHandler(stderr_handler)
-    return
+#     Raises:
+#         LoggerHandlerError: If a parent logger has a stderr handler.
+#     """
+#     if fallback_handlers is None:
+#         fallback_handlers = {HandlerType.Lstderr, HandlerType.Stream}
+#     check_parent_handlers(
+#         log,
+#         use_parent_handlers,
+#         logging.StreamHandler,
+#         target_stream=cast(io.IOBase, sys.stderr),
+#     )
+#     stderr_handler = logging.StreamHandler(sys.stderr)
+#     stderr_handler.setFormatter(LoggingFormatter())
+#     stderr_handler.addFilter(
+#         HandleIDFilter(
+#             handler_id=[HandlerType.Stream, HandlerType.Lstderr],
+#             fallback_handlers=fallback_handlers
+#             )
+#     )    
+#     stderr_handler.setLevel(logging.ERROR)
+#     log.addHandler(stderr_handler)
+#     return
+
+
 
 def add_file_handler(
     log: logging.Logger,
@@ -727,6 +465,10 @@ def add_file_handler(
     log.addHandler(file_handler)
     return
 
+
+
+
+# This is the big ol massive function..
 def add_handlers_from_types(
     log: logging.Logger,
     handler_types: set[HandlerType],

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from datetime import datetime
 from threading import Lock
-from typing import cast
+from typing import cast, Mapping, Any
 
 from erskafka.ERSKafkaLogHandler import ERSKafkaLogHandler
 from rich.logging import RichHandler
@@ -24,8 +24,11 @@ from daqpytools.logging.formatter import (
     TIME_ZONE,
     LoggingFormatter,
 )
+
+from daqpytools.logging.rich_handler import FormattedRichHandler
+from daqpytools.logging.specs import HandlerSpec, FilterSpec
+
 from daqpytools.logging.handlerdataclasses import (
-    FormattedRichHandler,
     HandlerType,
     LogHandlerConf,
 )
@@ -385,6 +388,93 @@ def logger_or_ancestors_have_handler(
         log, handler_type, target_stream
     ) or ancestors_have_handlers(log, use_parent_handlers, handler_type, target_stream)
 
+
+def _build_rich_handler(extras: Mapping[str, Any]) -> logging.Handler:
+    """Building the rich handler with any extras."""
+    width = cast(int,  extras.get("width", get_width()))
+    return FormattedRichHandler(width=width)
+
+
+RICH_HANDLER_SPEC = HandlerSpec(
+    representative_type = HandlerType.Rich,
+    handler_type = FormattedRichHandler,
+    factory=_build_rich_handler,
+    filter_handler_ids = (HandlerType.Rich,), # For HandleIDFilter
+)
+
+HANDLER_SPEC_REGISTRY : dict[HandlerType, tuple[HandlerSpec, ...]] = {
+    HandlerType.Rich: (RICH_HANDLER_SPEC,),
+}
+
+#! Lets try go tet the add rich handler thing running!
+
+
+def get_handler_specs(handler_type: HandlerType):
+    """Get the specs defined in the registry"""
+    return HANDLER_SPEC_REGISTRY.get(handler_type, tuple())
+
+
+#! This we should be careful with..
+def _resolve_default_case(
+    default_case: set[HandlerType] | None
+) -> set[HandlerType]:
+    "Return a safe copy of default_case with sensible fallback"
+    if default_case is None:
+        return LogHandlerConf.get_base()
+    return set(default_case)
+
+def add_handler(
+    log: logging.logger_has_filter,
+    spec: HandlerSpec,
+    use_parent_handlers:bool, 
+    fallback_handler: set[HandlerType] | None,
+    extras: Mapping[str, Any] | None = None,
+):
+    check_parent_handlers(
+        log,
+        use_parent_handlers,
+        spec.handler_type,
+        target_stream = spec.target_stream
+    )
+
+    handler = spec.factory(extras or {})
+    effective_default_case = _resolve_default_case(fallback_handler)
+
+    handler_ids: HandlerType | list[HandlerType]
+    if len(spec.filter_handler_ids) == 1:
+        handler_ids = cast(HandlerType, spec.filter_handler_ids[0])
+    else: 
+        handler_ids = [cast(HandlerType, handler_id) for handler_id in spec.filter_handler_ids] 
+
+    handler.addFilter(
+        HandleIDFilter(
+            handler_id=handler_ids,
+            fallback_handlers=effective_default_case
+        )
+    )
+
+    log.addHandler(handler)
+
+def add_rich_handler(
+    log: logging.Logger,
+    use_parent_handlers: bool,
+    fallback_handlers: set[HandlerType] | None = None,
+) -> None:
+    
+    add_handler(
+        log,
+        RICH_HANDLER_SPEC,
+        use_parent_handlers,
+        fallback_handlers
+    )
+
+##################################################################################################
+##################################################################################################
+##################################################################################################
+##################################################################################################
+##################################################################################################
+
+
 def add_throttle_filter(
     log: logging.Logger,
     fallback_handlers: set[HandlerType] | None = None,
@@ -404,39 +494,39 @@ def add_throttle_filter(
     log.addFilter(ThrottleFilter(fallback_handlers=fallback_handlers))
     return
 
-def add_rich_handler(
-    log: logging.Logger,
-    use_parent_handlers: bool,
-    fallback_handlers: set[HandlerType] | None = None,
-) -> None:
-    """Add a rich handler to the logger.
+# def add_rich_handler(
+#     log: logging.Logger,
+#     use_parent_handlers: bool,
+#     fallback_handlers: set[HandlerType] | None = None,
+# ) -> None:
+#     """Add a rich handler to the logger.
 
-    Args:
-        log (logging.Logger): Logger to add the rich handler to.
-        use_parent_handlers (bool): Whether to check parent handlers.
-        fallback_handlers (set[HandlerType] | None): Default handler set used when
-            records do not explicitly include handler routing.
+#     Args:
+#         log (logging.Logger): Logger to add the rich handler to.
+#         use_parent_handlers (bool): Whether to check parent handlers.
+#         fallback_handlers (set[HandlerType] | None): Default handler set used when
+#             records do not explicitly include handler routing.
 
-    Returns:
-        None
+#     Returns:
+#         None
 
-    Raises:
-        LoggerHandlerError: If a parent logger has a rich handler.
-    """
-    if fallback_handlers is None:
-        fallback_handlers = {HandlerType.Rich}
-    check_parent_handlers(log, use_parent_handlers, FormattedRichHandler)
-    width: int = get_width()
-    handler: RichHandler = FormattedRichHandler(width=width)    
+#     Raises:
+#         LoggerHandlerError: If a parent logger has a rich handler.
+#     """
+#     if fallback_handlers is None:
+#         fallback_handlers = {HandlerType.Rich}
+#     check_parent_handlers(log, use_parent_handlers, FormattedRichHandler)
+#     width: int = get_width()
+#     handler: RichHandler = FormattedRichHandler(width=width)    
     
-    handler.addFilter(
-        HandleIDFilter(
-            handler_id=HandlerType.Rich,
-            fallback_handlers=fallback_handlers
-            )
-    )
-    log.addHandler(handler)
-    return
+#     handler.addFilter(
+#         HandleIDFilter(
+#             handler_id=HandlerType.Rich,
+#             fallback_handlers=fallback_handlers
+#             )
+#     )
+#     log.addHandler(handler)
+#     return
 
 def add_ers_kafka_handler(
     log: logging.Logger,

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -468,6 +468,60 @@ def add_rich_handler(
         fallback_handlers
     )
 
+
+def _build_throttle_filter(
+    fallback_handlers: set[HandlerType],
+    extras: Mapping[str, Any],
+) -> logging.Filter:
+    """Build throttle filter from extras"""
+    initial_treshold = cast(int, extras.get("initial_treshold", 30))
+    time_limit = cast(int, extras.get("time_limit", 30))
+    return ThrottleFilter(
+        fallback_handlers=fallback_handlers,
+        initial_threshold=initial_treshold,
+        time_limit=time_limit
+    )
+
+THROTTLE_FILTER_SPEC = FilterSpec(
+    representative_type = HandlerType.Throttle,
+    filter_type = ThrottleFilter,
+    factory=_build_throttle_filter
+)
+
+FILTER_SPEC_REGISTRY: dict[HandlerType, FilterSpec] = {
+    HandlerType.Throttle: THROTTLE_FILTER_SPEC
+
+}
+
+def get_filter_spec(handler_types: HandlerType):
+    return FILTER_SPEC_REGISTRY.get(handler_types)
+
+def add_filter(
+    log: logging.Logger,
+    spec: FilterSpec,
+    fallback_handlers : set[HandlerType]| None,
+    extras: Mapping[str,Any] | None = None,
+) -> None:
+    """Add a logger filter according to the spec"""
+    logger_filter = spec.factory(_resolve_default_case(fallback_handlers), extras or {})
+    log.addFilter(logger_filter)
+
+
+def add_throttle_filter(
+    log: logging.Logger,
+    fallback_handlers: set[HandlerType] | None = None,
+) -> None:
+    "Add the Throttle filter to the logger"
+    add_filter(
+        log,
+        THROTTLE_FILTER_SPEC,
+        fallback_handlers
+    )
+
+
+# figureo ut how this mattches to the add_handlers bit, this is very important!
+
+
 ##################################################################################################
 ##################################################################################################
 ##################################################################################################

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -586,7 +586,7 @@ def logger_has_filter(log: logging.Logger, filter_type: type[logging.Filter]) ->
     """Check if logger already has a matching filter type."""
     return any(isinstance(logger_filter, filter_type) for logger_filter in log.filters)
 
-def check_parent_handlers(
+def ancestors_have_handlers(
     log: logging.Logger,
     use_parent_handlers: bool,
     handler_type: type[logging.Handler],
@@ -609,7 +609,7 @@ def check_parent_handlers(
     """
     # Sanity check
     if not use_parent_handlers:
-        return
+        return False
 
     # Check that we are not using the true logging root logger
     python_root_logger_name = logging.getLogger().name
@@ -634,10 +634,33 @@ def check_parent_handlers(
     this_is_root_logger = logger_parent.name == python_root_logger_name
     while not this_is_root_logger:
         if logger_has_handler(logger_parent,handler_type, target_stream):
-            raise LoggerHandlerError(logger_parent.name, handler_type)
+            return True
         logger_parent = logger_parent.parent
         this_is_root_logger = logger_parent.name == python_root_logger_name
-    return
+    return False
+
+
+def check_parent_handlers(
+    log: logging.Logger,
+    use_parent_handlers: bool,
+    handler_type: type[logging.Handler],
+    target_stream: io.IOBase | None = None,
+) -> None:
+    """Raise when a matching handler already exists on an ancestor logger."""
+    if ancestors_have_handlers(log, use_parent_handlers, handler_type, target_stream):
+        raise LoggerHandlerError(log.name, handler_type)
+    
+
+def logger_or_ancestors_have_handler(
+    log: logging.Logger,
+    use_parent_handlers: bool,
+    handler_type: type[logging.Handler],
+    target_stream: io.IOBase | None = None,
+) -> bool:
+    """Check if logger or (optionally) its ancestors have a matching handler."""
+    return logger_has_handler(
+        log, handler_type, target_stream
+    ) or ancestors_have_handlers(log, use_parent_handlers, handler_type, target_stream)
 
 def add_throttle_filter(
     log: logging.Logger,
@@ -863,68 +886,82 @@ def add_handlers_from_types(
     if HandlerType.Stream in effective_handler_types:
         effective_handler_types.update({HandlerType.Lstdout, HandlerType.Lstderr})
 
-    # Check if current logger has stream handlers, convert to handlertypes
-    existing_stream_handlers = {
-        HandlerType.Lstdout
-        if logger_has_handler(
-            log, logging.StreamHandler, target_stream=cast(io.IOBase, sys.stdout)
-        )
-        else None,
-        HandlerType.Lstderr
-        if logger_has_handler(
-            log, logging.StreamHandler, target_stream=cast(io.IOBase, sys.stderr)
-        )
-        else None,
+    # Generate handler configurations based on arguments for auto install
+    handler_configs: dict[
+        HandlerType,
+        tuple[
+            type[logging.Handler] | None, # Handler as seen by Python's Logger
+            io.IOBase | None, # Used for streamhandling
+            type[logging.Filter] | None, # For filters attached to loggers
+            Callable[[], None],  # Installer code
+        ],
+    ] = {
+        HandlerType.Rich: (
+            FormattedRichHandler,
+            None,
+            None,
+            lambda: add_rich_handler(log, use_parent_handlers, fallback_handlers),
+        ),
+        HandlerType.Lstdout: (
+            logging.StreamHandler,
+            cast(io.IOBase, sys.stdout),
+            None,
+            lambda: add_stdout_handler(log, use_parent_handlers, fallback_handlers),
+        ),
+        HandlerType.Lstderr: (
+            logging.StreamHandler,
+            cast(io.IOBase, sys.stderr),
+            None,
+            lambda: add_stderr_handler(log, use_parent_handlers, fallback_handlers),
+        ),
+        HandlerType.Protobufstream: (
+            ERSKafkaLogHandler,
+            None,
+            None,
+            lambda: add_ers_kafka_handler(
+                log, use_parent_handlers, ers_session_name, fallback_handlers
+            ),
+        ),
+        HandlerType.Throttle: (
+            None,
+            None,
+            ThrottleFilter,
+            lambda: add_throttle_filter(log, fallback_handlers),
+        ),
+        HandlerType.File: (
+            logging.FileHandler,
+            None,
+            None,
+            lambda: add_file_handler(
+                log, use_parent_handlers, file_name, fallback_handlers
+            ),
+        ),
     }
-    existing_stream_handlers.discard(None)
 
-    # Check if current logger has the interested handler
-    existing_handlers = {
-        HandlerType.Rich if logger_has_handler(log, FormattedRichHandler) else None,
-        HandlerType.Protobufstream
-        if logger_has_handler(log, ERSKafkaLogHandler)
-        else None,
-        HandlerType.Throttle if logger_has_filter(log, ThrottleFilter) else None,
-        HandlerType.File if logger_has_filter(log, logging.FileHandler) else None,
-    }
-    existing_handlers.discard(None)
-    existing_handlers.update(existing_stream_handlers)
 
-    handlers_init_map: dict[HandlerType, Callable[[], None]] = {
-        HandlerType.Rich: lambda: add_rich_handler(
-            log, use_parent_handlers, fallback_handlers
-        ),
-        HandlerType.Lstdout: lambda: add_stdout_handler(
-            log, use_parent_handlers, fallback_handlers
-        ),
-        HandlerType.Lstderr: lambda: add_stderr_handler(
-            log, use_parent_handlers, fallback_handlers
-        ),
-        HandlerType.File: lambda: add_file_handler(
-            log, use_parent_handlers, file_name, fallback_handlers
-        ),
-        HandlerType.Protobufstream: lambda: add_ers_kafka_handler(
-            log, use_parent_handlers, ers_session_name, fallback_handlers
-        ),
-        HandlerType.Throttle: lambda: add_throttle_filter(log, fallback_handlers),
-    }
-
-    # Need to clean this bit up
-    supported_handers = [
-        HandlerType.Rich,
-        HandlerType.Lstdout,
-        HandlerType.Lstderr,
-        HandlerType.Protobufstream,
-        HandlerType.Throttle,
-        HandlerType.File,
-    ]
-
-    for handler_type in supported_handers:
+    for handler_type, (
+        handler_class,
+        target_stream,
+        filter_type,
+        installer,
+    ) in handler_configs.items():
+        
+        # Skips if it encounters an unrequested handler
         if handler_type not in effective_handler_types:
             continue
-        if handler_type in existing_handlers:
+        
+        # Skips if handler/filter exists in either the logger or any of its ancestors
+        handler_exists = (
+            handler_class is not None
+            and logger_or_ancestors_have_handler(
+                log,
+                use_parent_handlers,
+                handler_class,
+                target_stream=target_stream,
+            )
+        ) or (filter_type is not None and logger_has_filter(log, filter_type))
+        
+        if handler_exists:
             continue
-        installer = handlers_init_map.get(handler_type)
-        if installer is None:
-            continue
+        
         installer()

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -193,6 +193,7 @@ class ERSPyLogHandlerConf:
     handlers: list = field(default_factory = lambda: [])
     protobufconf: ProtobufConf = field(default_factory = lambda: None)
 
+#! TODO/now= consider @dataclass(frozen=True)
 @dataclass
 class LogHandlerConf:
     """Dataclass that holds the various streams and relevant handlers.
@@ -344,8 +345,9 @@ class BaseHandlerFilter(logging.Filter):
     """Base filter that hold the logic on choosing if a handler should emit
     based on what HandlersTypes are supplied to it.
     """
-    def __init__(self) -> None:
+    def __init__(self, default_case = LogHandlerConf.get_base() ) -> None:
         """C'tor."""
+        self.default_case = default_case
         super().__init__()
     
     def get_allowed(self, record: logging.LogRecord) -> list | None:
@@ -370,7 +372,7 @@ class BaseHandlerFilter(logging.Filter):
 
         # Handle the non-ERS case
         else:
-            allowed = getattr(record, "handlers", LogHandlerConf.get_base()) 
+            allowed = getattr(record, "handlers", self.default_case) 
         return allowed
         
 class HandleIDFilter(BaseHandlerFilter):
@@ -378,11 +380,13 @@ class HandleIDFilter(BaseHandlerFilter):
     if the current handler (defined by the handler_id) is within the set of 
     allowed handlers.
     """
-    def __init__(self, handler_id: HandlerType | list[HandlerType]) -> None:
+    def __init__(self, handler_id: HandlerType | list[HandlerType], default_case = LogHandlerConf.get_base()) -> None:
         """Initialises HandleIDFilter with the handler_id, to identify what
         kind of handler this filter is.
         """
-        super().__init__()
+        super().__init__(
+            default_case = default_case
+        )
         
         # Normalise handler_id to be a set
         if isinstance(handler_id, list):
@@ -560,6 +564,23 @@ def add_throttle_filter(log: logging.Logger) -> None:
     log.addFilter(ThrottleFilter())
     return
 
+def _logger_has_handler(
+    log: logging.Logger,
+    handler_type: type[logging.Handler],
+    target_stream: io.IOBase | None = None,
+) -> bool:
+    """Check if logger already has a matching handler.
+
+    For StreamHandler, ``target_stream`` can be used to distinguish stdout/stderr.
+    """
+    type_matches = [isinstance(handler, handler_type) for handler in log.handlers]
+    stream_matches = [
+        handler.stream is target_stream if target_stream else False
+        for handler in log.handlers
+        if isinstance(handler, logging.StreamHandler)
+    ]
+    return any(type_matches + stream_matches)
+
 def check_parent_handlers(
     log: logging.Logger,
     use_parent_handlers: bool,
@@ -588,8 +609,9 @@ def check_parent_handlers(
     # Check that we are not using the true logging root logger
     python_root_logger_name = logging.getLogger().name
     if log.name == python_root_logger_name:
-        err_nsg = "You should not be interfacing with the root logger"
-        raise ValueError(err_nsg)
+        err_msg = "You should not be interfacing with the root logger"
+        raise ValueError(err_msg)
+        
     # Validate the stream handler has a target stream
     if handler_type.__name__ == "StreamHandler" and target_stream is None:
         err_msg = (
@@ -607,15 +629,7 @@ def check_parent_handlers(
     logger_parent = log.parent
     this_is_root_logger = logger_parent.name == python_root_logger_name
     while not this_is_root_logger:
-        handler_checking = [
-            isinstance(handler, handler_type) for handler in logger_parent.handlers
-        ]
-        stream_handler_checking = [
-            handler.stream is target_stream if target_stream else False
-            for handler in logger_parent.handlers
-            if isinstance(handler, logging.StreamHandler)
-        ]
-        if any(handler_checking + stream_handler_checking):
+        if _logger_has_handler(logger_parent,handler_type, target_stream):
             raise LoggerHandlerError(logger_parent.name, handler_type)
         logger_parent = logger_parent.parent
         this_is_root_logger = logger_parent.name == python_root_logger_name
@@ -638,10 +652,14 @@ def add_rich_handler(log: logging.Logger, use_parent_handlers: bool) -> None:
     check_parent_handlers(log, use_parent_handlers, FormattedRichHandler)
     width: int = get_width()
     handler: RichHandler = FormattedRichHandler(width=width)
-    handler.addFilter(HandleIDFilter(HandlerType.Rich))
+
+    #! Here you better initialise handlerid filter
+    my_default_case = {HandlerType.Rich}
+    my_rich_filter = HandleIDFilter(handler_id=HandlerType.Rich, default_case=my_default_case) # Should accept the base handlers here
+    handler.addFilter(my_rich_filter)
     log.addHandler(handler)
     return
-    
+
 def add_ers_kafka_handler(log: logging.Logger, use_parent_handlers: bool,
                                  session_name:str, topic: str = "ers_stream", 
                                  address: str ="monkafka.cern.ch:30092") -> None:
@@ -676,11 +694,16 @@ def add_stdout_handler(log: logging.Logger, use_parent_handlers: bool) -> None:
     )
     stdout_handler = logging.StreamHandler(sys.stdout)
     stdout_handler.setFormatter(LoggingFormatter())
-    stdout_handler.addFilter(HandleIDFilter([HandlerType.Stream, HandlerType.Lstdout]))
+    
+    # repeat ad infinitum for all handlers.... 
+    my_default_case = {HandlerType.Rich}
+    my_stdout_filter = HandleIDFilter(handler_id=[HandlerType.Stream, HandlerType.Lstdout],default_case=my_default_case)
+    stdout_handler.addFilter(my_stdout_filter)
+    
     log.addHandler(stdout_handler)
     return
 
-
+# Consider seeing if there is a way to generalify the add X handler..
 def add_stderr_handler(log: logging.Logger, use_parent_handlers: bool) -> None:
     """Add a stderr handler to the logger.
 
@@ -734,24 +757,6 @@ def add_file_handler(log: logging.Logger, use_parent_handlers: bool, path: str) 
     return
 
 
-def _logger_has_handler(
-    log: logging.Logger,
-    handler_type: type[logging.Handler],
-    target_stream: io.IOBase | None = None,
-) -> bool:
-    """Check if logger already has a matching handler.
-
-    For StreamHandler, ``target_stream`` can be used to distinguish stdout/stderr.
-    """
-    type_matches = [isinstance(handler, handler_type) for handler in log.handlers]
-    stream_matches = [
-        handler.stream is target_stream if target_stream else False
-        for handler in log.handlers
-        if isinstance(handler, logging.StreamHandler)
-    ]
-    return any(type_matches + stream_matches)
-
-
 def _logger_has_filter(log: logging.Logger, filter_type: type[logging.Filter]) -> bool:
     """Check if logger already has a matching filter type."""
     return any(isinstance(logger_filter, filter_type) for logger_filter in log.filters)
@@ -762,7 +767,7 @@ def add_handlers_from_types(
     handler_types: set[HandlerType],
     ers_session_name: str | None,
 ) -> None:
-    """Add handlers to a logger based on HandlerType values.
+    """Add handlers to a logger based on a set of HandlerType values.
 
     This helper intentionally supports only the default options for now:
     - ``use_parent_handlers`` is always True.
@@ -777,10 +782,12 @@ def add_handlers_from_types(
         err_msg = "ers_session_name is required for HandlerType.Protobufstream"
         raise ValueError(err_msg)
 
+    # Update relevant handler types that was parsed
     effective_handler_types = set(handler_types)
     if HandlerType.Stream in effective_handler_types:
         effective_handler_types.update({HandlerType.Lstdout, HandlerType.Lstderr})
 
+    # Check if current logger has stream handlers, convert to handlertypes
     existing_stream_handlers = {
         HandlerType.Lstdout
         if _logger_has_handler(
@@ -795,6 +802,7 @@ def add_handlers_from_types(
     }
     existing_stream_handlers.discard(None)
 
+    # Check if current logger has the interested handler
     existing_handlers = {
         HandlerType.Rich if _logger_has_handler(log, FormattedRichHandler) else None,
         HandlerType.Protobufstream
@@ -805,7 +813,7 @@ def add_handlers_from_types(
     existing_handlers.discard(None)
     existing_handlers.update(existing_stream_handlers)
 
-    dispatch = {
+    handlers_init_map = {
         HandlerType.Rich: lambda: add_rich_handler(log, True),
         HandlerType.Lstdout: lambda: add_stdout_handler(log, True),
         HandlerType.Lstderr: lambda: add_stderr_handler(log, True),
@@ -815,9 +823,7 @@ def add_handlers_from_types(
         HandlerType.Throttle: lambda: add_throttle_filter(log)
     }
 
-    #! Try to revisit this logic
-
-    install_order = [
+    supported_handers = [
         HandlerType.Rich,
         HandlerType.Lstdout,
         HandlerType.Lstderr,
@@ -825,12 +831,12 @@ def add_handlers_from_types(
         HandlerType.Throttle,
     ]
 
-    for handler_type in install_order:
+    for handler_type in supported_handers:
         if handler_type not in effective_handler_types:
             continue
         if handler_type in existing_handlers:
             continue
-        installer = dispatch.get(handler_type)
+        installer = handlers_init_map.get(handler_type)
         if installer is None:
             continue
         installer()

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -423,9 +423,13 @@ class ThrottleFilter(BaseHandlerFilter):
         ...     logger.error("Repeated error message")
     """
     
-    def __init__(self, initial_threshold: int = 30, time_limit:  int = 30) -> None:
+    def __init__(self, default_case=LogHandlerConf.get_base(), initial_threshold: int = 30, time_limit:  int = 30) -> None:
         """C'tor."""
-        super().__init__()
+        #! THERES A BUG HERE.. WHERE IF YOU WRONGLY INITIALISE IT ITS NOT GONNA FIRE AT ALL.........
+        
+        super().__init__(
+            default_case = default_case
+            )
         self.initial_threshold = initial_threshold
         self.time_limit = time_limit
         self.issue_map: dict[str, IssueRecord] = defaultdict(IssueRecord)
@@ -552,7 +556,7 @@ class ThrottleFilter(BaseHandlerFilter):
         return Text(time_str, style="logging.time")
     
 
-def add_throttle_filter(log: logging.Logger) -> None:
+def add_throttle_filter(log: logging.Logger, default_case = {HandlerType.Throttle}) -> None:
     """Add the Throttle filter to the logger.
 
     Args:
@@ -561,7 +565,7 @@ def add_throttle_filter(log: logging.Logger) -> None:
     Returns:
         None
     """
-    log.addFilter(ThrottleFilter())
+    log.addFilter(ThrottleFilter(default_case=default_case))
     return
 
 def _logger_has_handler(
@@ -573,12 +577,32 @@ def _logger_has_handler(
 
     For StreamHandler, ``target_stream`` can be used to distinguish stdout/stderr.
     """
-    type_matches = [isinstance(handler, handler_type) for handler in log.handlers]
-    stream_matches = [
-        handler.stream is target_stream if target_stream else False
-        for handler in log.handlers
-        if isinstance(handler, logging.StreamHandler)
-    ]
+    #EXCEPT STREAM HANDLER YOU FOOL
+    type_matches = [isinstance(handler, handler_type) for handler in log.handlers if not isinstance(handler, logging.StreamHandler)]
+
+    
+    stream_matches = []
+
+    # print(f"{handler_type=},{target_stream = } ")
+
+    for handler in log.handlers:
+        if isinstance(handler, logging.StreamHandler):
+            # print(f"{handler=}, {handler.stream=}")
+            if target_stream:
+                # print("Target stream")
+                if handler.stream is target_stream:
+                    # print("dice")
+                    stream_matches.append(True)
+                else:
+                    # print("no dice")
+                    stream_matches.append(False)
+            else:
+                # print("No Stream")
+                stream_matches.append(False)
+            
+    # print(f"{type_matches=}, {stream_matches=}" )
+    # print(f"outcome: {any(type_matches + stream_matches)}")
+    # print("")
     return any(type_matches + stream_matches)
 
 def check_parent_handlers(
@@ -636,7 +660,7 @@ def check_parent_handlers(
     return
 
 
-def add_rich_handler(log: logging.Logger, use_parent_handlers: bool) -> None:
+def add_rich_handler(log: logging.Logger, use_parent_handlers: bool, default_case={HandlerType.Rich}) -> None:
     """Add a rich handler to the logger.
 
     Args:
@@ -654,14 +678,14 @@ def add_rich_handler(log: logging.Logger, use_parent_handlers: bool) -> None:
     handler: RichHandler = FormattedRichHandler(width=width)
 
     #! Here you better initialise handlerid filter
-    my_default_case = {HandlerType.Rich}
-    my_rich_filter = HandleIDFilter(handler_id=HandlerType.Rich, default_case=my_default_case) # Should accept the base handlers here
-    handler.addFilter(my_rich_filter)
+    
+    my_filter = HandleIDFilter(handler_id=HandlerType.Rich, default_case=default_case) # Should accept the base handlers here
+    handler.addFilter(my_filter)
     log.addHandler(handler)
     return
 
 def add_ers_kafka_handler(log: logging.Logger, use_parent_handlers: bool,
-                                 session_name:str, topic: str = "ers_stream", 
+                                 session_name:str, default_case = {HandlerType.Protobufstream}, topic: str = "ers_stream", 
                                  address: str ="monkafka.cern.ch:30092") -> None:
     # TODO/future: topic and address are new, propagate to all relevant implementation
     """Add an ers protobuf handler to the root logger."""
@@ -670,10 +694,13 @@ def add_ers_kafka_handler(log: logging.Logger, use_parent_handlers: bool,
                                                      kafka_address = address, 
                                                      kafka_topic = topic
                                                      )
-    handler.addFilter(HandleIDFilter(HandlerType.Protobufstream))
+    
+        
+    my_filter = HandleIDFilter(HandlerType.Protobufstream, default_case=default_case)
+    handler.addFilter(my_filter)
     log.addHandler(handler)
 
-def add_stdout_handler(log: logging.Logger, use_parent_handlers: bool) -> None:
+def add_stdout_handler(log: logging.Logger, use_parent_handlers: bool, default_case={HandlerType.Stream, HandlerType.Lstdout}) -> None:
     """Add a stdout handler to the logger.
 
     Args:
@@ -696,15 +723,14 @@ def add_stdout_handler(log: logging.Logger, use_parent_handlers: bool) -> None:
     stdout_handler.setFormatter(LoggingFormatter())
     
     # repeat ad infinitum for all handlers.... 
-    my_default_case = {HandlerType.Rich}
-    my_stdout_filter = HandleIDFilter(handler_id=[HandlerType.Stream, HandlerType.Lstdout],default_case=my_default_case)
-    stdout_handler.addFilter(my_stdout_filter)
+    my_filter = HandleIDFilter(handler_id=[HandlerType.Stream, HandlerType.Lstdout],default_case=default_case)
+    stdout_handler.addFilter(my_filter)
     
     log.addHandler(stdout_handler)
     return
 
 # Consider seeing if there is a way to generalify the add X handler..
-def add_stderr_handler(log: logging.Logger, use_parent_handlers: bool) -> None:
+def add_stderr_handler(log: logging.Logger, use_parent_handlers: bool, default_case={HandlerType.Lstderr, HandlerType.Stream}) -> None:
     """Add a stderr handler to the logger.
 
     The error is set to the ERROR level, and will only log messages at that level
@@ -729,13 +755,16 @@ def add_stderr_handler(log: logging.Logger, use_parent_handlers: bool) -> None:
     )
     stderr_handler = logging.StreamHandler(sys.stderr)
     stderr_handler.setFormatter(LoggingFormatter())
-    stderr_handler.addFilter(HandleIDFilter([HandlerType.Stream, HandlerType.Lstderr]))
+    
+    my_filter = HandleIDFilter(handler_id=[HandlerType.Stream, HandlerType.Lstderr],default_case=default_case)
+    stderr_handler.addFilter(my_filter)
+    
     stderr_handler.setLevel(logging.ERROR)
     log.addHandler(stderr_handler)
     return
 
 
-def add_file_handler(log: logging.Logger, use_parent_handlers: bool, path: str) -> None:
+def add_file_handler(log: logging.Logger, use_parent_handlers: bool, path: str, default_case={HandlerType.File}) -> None:
     """Add a file handler to the root logger.
 
     Args:
@@ -752,7 +781,10 @@ def add_file_handler(log: logging.Logger, use_parent_handlers: bool, path: str) 
     check_parent_handlers(log, use_parent_handlers, logging.FileHandler)
     file_handler = logging.FileHandler(filename=path)
     file_handler.setFormatter(LoggingFormatter())
-    file_handler.addFilter(HandleIDFilter(HandlerType.File))
+    
+    my_filter = HandleIDFilter(HandlerType.File, default_case)
+    file_handler.addFilter(my_filter)
+    
     log.addHandler(file_handler)
     return
 
@@ -774,6 +806,8 @@ def add_handlers_from_types(
     - ``HandlerType.File`` is not supported and raises immediately.
     - ``HandlerType.Protobufstream`` requires ``ers_session_name``.
     """
+
+    default_case = {HandlerType.Unknown}
     if HandlerType.File in handler_types:
         err_msg = "HandlerType.File is not supported by add_handlers_from_types"
         raise ValueError(err_msg)
@@ -801,6 +835,7 @@ def add_handlers_from_types(
         else None,
     }
     existing_stream_handlers.discard(None)
+    print(f"{existing_stream_handlers=}")
 
     # Check if current logger has the interested handler
     existing_handlers = {
@@ -813,14 +848,17 @@ def add_handlers_from_types(
     existing_handlers.discard(None)
     existing_handlers.update(existing_stream_handlers)
 
+    # print(f"{existing_handlers=}")
+    # print(f"{effective_handler_types=}")
+
     handlers_init_map = {
-        HandlerType.Rich: lambda: add_rich_handler(log, True),
-        HandlerType.Lstdout: lambda: add_stdout_handler(log, True),
-        HandlerType.Lstderr: lambda: add_stderr_handler(log, True),
+        HandlerType.Rich: lambda: add_rich_handler(log, True, default_case),
+        HandlerType.Lstdout: lambda: add_stdout_handler(log, True, default_case),
+        HandlerType.Lstderr: lambda: add_stderr_handler(log, True, default_case),
         HandlerType.Protobufstream: lambda: add_ers_kafka_handler(
-            log, True, ers_session_name
+            log, True, ers_session_name, default_case
         ),
-        HandlerType.Throttle: lambda: add_throttle_filter(log)
+        HandlerType.Throttle: lambda: add_throttle_filter(log, {HandlerType.Rich})
     }
 
     supported_handers = [
@@ -839,5 +877,7 @@ def add_handlers_from_types(
         installer = handlers_init_map.get(handler_type)
         if installer is None:
             continue
+        print(handler_type)
+
         installer()
 

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -569,6 +569,10 @@ def logger_has_handler(
 
     For StreamHandler, ``target_stream`` can be used to distinguish stdout/stderr.
     """
+    # Catches cases when a MockLogger is used in pytest
+    if not isinstance(log, logging.Logger):
+        return False
+
     type_matches = [
         isinstance(handler, handler_type)
         for handler in log.handlers
@@ -584,6 +588,9 @@ def logger_has_handler(
 
 def logger_has_filter(log: logging.Logger, filter_type: type[logging.Filter]) -> bool:
     """Check if logger already has a matching filter type."""
+    if not isinstance(log, logging.Logger):
+        return False
+
     return any(isinstance(logger_filter, filter_type) for logger_filter in log.filters)
 
 def ancestors_have_handlers(
@@ -611,6 +618,9 @@ def ancestors_have_handlers(
     if not use_parent_handlers:
         return False
 
+    if not isinstance(log, logging.Logger):
+        return False
+
     # Check that we are not using the true logging root logger
     python_root_logger_name = logging.getLogger().name
     if log.name == python_root_logger_name:
@@ -631,12 +641,20 @@ def ancestors_have_handlers(
         raise ValueError(err_msg)
 
     logger_parent = log.parent
-    this_is_root_logger = logger_parent.name == python_root_logger_name
-    while not this_is_root_logger:
+    visited_logger_ids: set[int] = set()
+
+    while isinstance(logger_parent, logging.Logger):
+        logger_id = id(logger_parent)
+        if logger_id in visited_logger_ids:
+            return False # Prevents infinite loop
+        visited_logger_ids.add(logger_id)
+
+        if logger_parent.name == python_root_logger_name:
+            break
+
         if logger_has_handler(logger_parent,handler_type, target_stream):
             return True
         logger_parent = logger_parent.parent
-        this_is_root_logger = logger_parent.name == python_root_logger_name
     return False
 
 

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -3,323 +3,38 @@ from __future__ import annotations
 import copy
 import io
 import logging
-import os
-import re
 import sys
 import time
 from collections import defaultdict
 from collections.abc import Callable
-from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
 from threading import Lock
-from typing import ClassVar, cast
+from typing import cast
 
 from erskafka.ERSKafkaLogHandler import ERSKafkaLogHandler
-from rich.console import Console, ConsoleRenderable
 from rich.logging import RichHandler
 from rich.text import Text
 
 from daqpytools.logging.exceptions import (
-    ERSEnvError,
     LoggerHandlerError,
-    ProtobufFormatError,
 )
 from daqpytools.logging.formatter import (
-    CONSOLE_THEME,
     DATE_TIME_BASE_FORMAT,
-    DATE_TIME_FORMAT,
     LOG_RECORD_PADDING,
     TIME_ZONE,
     LoggingFormatter,
 )
-from daqpytools.logging.levels import level_to_ers_var, logging_log_level_to_str
+from daqpytools.logging.handlerdataclasses import (
+    FormattedRichHandler,
+    HandlerType,
+    LogHandlerConf,
+)
+from daqpytools.logging.routing import (
+    AllowedHandlersStrategy,
+    StreamAwareAllowedHandlersStrategy,
+)
 from daqpytools.logging.utils import get_width
 
-
-class FormattedRichHandler(RichHandler):
-    """RichHandler that formats log messages with time, aligned columns, and styles."""
-
-    def __init__(self, width: int = 100) -> None:
-        """Initialize with custom console and style settings."""
-        console: Console = Console(
-            force_terminal=True, width=width, theme=CONSOLE_THEME
-        )
-        super().__init__(
-            console=console,
-            omit_repeated_times=False,
-            markup=True,
-            rich_tracebacks=True,
-            show_path=False,
-            show_time=False,  # We format time ourselves
-        )
-
-    def render(
-        self,
-        *,
-        record: logging.LogRecord,
-        traceback: object,
-        message_renderable: ConsoleRenderable,
-    ) -> Text:
-        """Render the log record into a rich Text object with custom formatting.
-
-        Args:
-            record (logging.LogRecord): The log record to render.
-            traceback (object): The traceback object (not used here).
-            message_renderable (ConsoleRenderable): The log message renderable.
-
-        Returns:
-            Text: The formatted log record as a rich Text object.
-
-        Raises:
-            None
-        """
-        dt: datetime = datetime.fromtimestamp(record.created, tz=TIME_ZONE)
-        padding: int = LOG_RECORD_PADDING.get("time", 25)
-        time_str: str = dt.strftime(DATE_TIME_FORMAT).ljust(padding)[:padding]
-        time_text: Text = Text(time_str, style="logging.time")
-
-        padding = LOG_RECORD_PADDING.get("level", 10)
-        level_text: Text = Text(
-            record.levelname.ljust(padding)[:padding],
-            style=self._get_level_style(record.levelno),
-        )
-
-        file_and_no: str = f"{record.filename}:{record.lineno}"
-        padding = LOG_RECORD_PADDING.get("file_and_line", 40)
-        file_and_no_text: Text = Text(
-            file_and_no.ljust(padding)[:padding], style="logging.location"
-        )
-
-        padding = LOG_RECORD_PADDING.get("logger_name", 45)
-        logger_name_text: Text = Text(
-            f"{record.name}".ljust(padding)[:padding], style="logging.logger_name"
-        )
-
-        # Convert message_renderable to Text for type consistency
-        message_text: Text
-        if isinstance(message_renderable, Text):
-            message_text = message_renderable
-        else:
-            message_text = Text.from_markup(str(message_renderable))
-
-        components: list[Text] = [
-            time_text,
-            level_text,
-            file_and_no_text,
-            logger_name_text,
-            message_text,
-        ]
-
-        return Text(" ").join(components)
-
-    def _get_level_style(self, level_no: int) -> str:
-        """Get the style string for the given log level number from the theme defined in
-        CONSOLE_THEME.
-
-        Args:
-            level_no (int): The log level number.
-
-        Returns:
-            str: The style string for the log level.
-        """
-        return str(
-            CONSOLE_THEME.styles.get(
-                f"logging.level.{logging_log_level_to_str(level_no).lower()}", ""
-            )
-        )
-
-# Initialise a logger to catch erstrace + other unknown handlertypes from OKS
-log: logging.Logger = logging.getLogger(__name__)
-log.addHandler(FormattedRichHandler(width=get_width()))
-log.setLevel("INFO")
-
-
-class StreamType(Enum):
-    """Enumtype to classify the set of relevant handlers (i.e streams)."""
-    BASE="base"
-    OPMON="opmon"
-    ERS="ers"
-
-@dataclass 
-class ProtobufConf:
-    """Dataclass to hold Protobuf Configuration."""
-    url:str= "monkafka.cern.ch"
-    port:int= 30092
-
-    def get_string(self) -> str:
-        """Converts back to string version."""
-        return f"{self.url}:{self.port}"
-
-class HandlerType(Enum):
-    """Enumtype to classify the existing set of Handlers.
-    Values must match exactly what is given in the OKS configuration, if any
-    All are in lowercase.
-    """
-    Unknown = "unknown"
-    Stream = "stream"
-    Rich = "rich"
-    File = "file"
-    Protobufstream = "protobufstream"
-    Lstdout = "lstdout"
-    Lstderr = "lstderr"
-    Throttle = "throttle"
-    @classmethod
-    def from_string(cls, s: str) -> HandlerType | None:
-        """Converts from a case-independent string to HandlerType."""
-        try:
-            return HandlerType(s.lower())
-        except ValueError:
-            msg=f"[red]{s}[/red] is not a known handler type"
-            log.warning(msg)
-            return None
-
-
-@dataclass
-class ERSPyLogHandlerConf:
-    """Dataclass that holds the relevant ERS configuration from OKS.
-
-    As an example, given the following
-    <obj class="Variable" id="ehn1-env-ers-error">
-        <attr name="name" type="string" val="DUNEDAQ_ERS_ERROR"/>
-        <attr name="value" type="string" val="erstrace,throttle,lstdout,
-            protobufstream(monkafka.cern.ch:30092)"/>
-    </obj>
-
-    This dataclass holds the list of relevant Handlers attached to the ERS log level. 
-    In case it also contains a single protobuf handler, the configuration is stored by 
-    the ProtobufConf instance. Multiple protobuf handlers with different url/ports 
-    are not yet supported.
-    """
-    handlers: list = field(default_factory = lambda: [])
-    protobufconf: ProtobufConf = field(default_factory = lambda: None)
-
-@dataclass
-class LogHandlerConf:
-    """Dataclass that holds the various streams and relevant handlers.
-    
-    Attributes:
-        init_ers: If True, automatically initializes ERS configuration 
-            during construction.
-        _BASE_HANDLERS: Private class variable for default base handlers
-        _OPMON_HANDLERS: Private class variable for opmon handlers
-        BASE_CONFIG: Class variable for base stream configuration
-        OPMON_CONFIG: Class variable for opmon stream configuration
-        ERS: Instance field for ERS configuration (loaded from environment)
-    """
-    init_ers: bool = False
-
-    _BASE_HANDLERS: ClassVar[set] = {HandlerType.Stream, HandlerType.Rich,
-        HandlerType.File
-        }
-    _OPMON_HANDLERS: ClassVar[set] = {HandlerType.Rich, HandlerType.Stream,
-        HandlerType.File}
-    _ERS: object = None
-    
-    Base: ClassVar[dict] = {
-        "handlers": _BASE_HANDLERS,
-        "stream": StreamType.BASE
-    }
-    
-    Opmon: ClassVar[dict] = {
-        "handlers": _OPMON_HANDLERS,
-        "stream": StreamType.OPMON
-    }
-
-    def __post_init__(self) -> None:
-        """Initialize ERS configuration if init_ers field is True.
-
-        This method is called automatically after dataclass initialization.
-        If the init_ers attribute was set to True, it triggers the complete
-        ERS initialization.
-        """
-        if self.init_ers:
-            self.init_ers_stream()
-
-    @property
-    def ERS(self) -> dict : # noqa: N802
-        """Get the ERS configuration dictionary.
-        
-        Returns:
-            dict: Contains 'ers_handlers' and 'stream' configuration for ERS
-            
-        Raises:
-            AttributeError: If ERS has not been
-                initialized (call init_ers_stream() first)
-        """
-        if not self._ERS:
-            err_msg = "ERS stream not initialised. Call init_ers_stream() first"
-            raise AttributeError(err_msg)
-        return self._ERS
-
-    def init_ers_stream(self) -> None:
-        """Initialize ERS configuration from environment variables.
-        
-        Loads ERS configuration from OKS environment variables and populates
-        the _ERS dict with handlers and stream information.
-        
-        Called automatically during construction if init_ers=True, or can be
-        called manually afterwards.
-        """
-        self._ERS = {
-            "ers_handlers":  LogHandlerConf._get_oks_conf(),
-            "stream": StreamType.ERS
-        }   
-
-    @staticmethod
-    def _convert_str_to_handlertype(handler_str: str) -> tuple[HandlerType,
-        ProtobufConf | None]:
-        """Parses a given environment variable to obtain the
-        HandlerType and ProtobufConf as necessary. 
-
-        Eg. converts "throttle" to HandlerType.Throttle
-            converts "protobufstream(url:port)" to return both the HandlerType and the 
-            protobuf configuration
-        """
-        if "erstrace" in handler_str:
-            msg = (
-                "ERSTrace is a C++ implementation, "
-                "does not have an equivalent in Python"
-            )
-            log.debug(msg)
-            return None, None
-
-        if HandlerType.Protobufstream.value not in handler_str:
-            return HandlerType.from_string(handler_str), None
-
-        match = re.search(r"\(([^:]+):(\d+)\)", handler_str)
-        if not match:
-            raise ProtobufFormatError(handler_str)
-        url, port = match.group(1), int(match.group(2))
-        return HandlerType.Protobufstream, ProtobufConf(url=url, port=port)
-
-    @staticmethod
-    def _make_ers_handler_conf(ers_log_level :str) -> ERSPyLogHandlerConf:
-        """Generates the ERSPyLogHandlerConf from reading an environment variable."""
-        erspyloghandlerconf = ERSPyLogHandlerConf()
-        envvalue = os.getenv(ers_log_level)
-        if envvalue is None:
-            raise ERSEnvError(ers_log_level)
-        
-        for h in envvalue.split(","):
-            handlertype, kafkaconf = LogHandlerConf._convert_str_to_handlertype(h)
-            erspyloghandlerconf.handlers.append(handlertype)
-            if kafkaconf:
-                erspyloghandlerconf.protobufconf = kafkaconf 
-        return erspyloghandlerconf
-
-    @staticmethod
-    def _get_oks_conf() -> dict:
-        """From the set of known environment variables, generate the ERS conf dict."""
-        return {var: LogHandlerConf._make_ers_handler_conf(var) 
-            for var in list(level_to_ers_var.values())}
-    
-    @staticmethod
-    def get_base() -> set[HandlerType]:
-        """Returns the default list of handlers from
-        LogHandlerConf._BASE_HANDLERS without having to initialise an instance.
-        """
-        return LogHandlerConf._BASE_HANDLERS
 
 class IssueRecord:
     """Tracks throttling state for a unique issue (identified by file: line)."""
@@ -341,37 +56,23 @@ class BaseHandlerFilter(logging.Filter):
     """Base filter that hold the logic on choosing if a handler should emit
     based on what HandlersTypes are supplied to it.
     """
-    def __init__(self, fallback_handlers: set[HandlerType] | None = None) -> None:
+    def __init__(
+        self,
+        fallback_handlers: set[HandlerType] | None = None,
+        allowed_handlers_strategy : AllowedHandlersStrategy | None = None,
+    ) -> None:
         """C'tor."""
-        if fallback_handlers is None:
-            fallback_handlers = set(LogHandlerConf.get_base())
-        self.fallback_handlers = fallback_handlers
+        self.fallback_handlers = set(fallback_handlers) if fallback_handlers is not None else LogHandlerConf.get_base() #! We should check if this is still the case
+
+        self.allowed_handlers_strategy = (
+            allowed_handlers_strategy or 
+            StreamAwareAllowedHandlersStrategy()
+        )
         super().__init__()
-    
-    def get_allowed(self, record: logging.LogRecord) -> list | None:
-        """Parses the record to obtain the set of Handlers that allows transmission."""
-        # TODO/future: kafkaprotobufs should validate url/port match before transmitting
-        
-        # Handle the ERS case, requires more processing
-        if getattr(record, "stream", None) == StreamType.ERS:
-            # Chain None checks using walrus operator
-            if (
-                # Checks if python log level has an ERS severity level match
-                (ers_level_var := level_to_ers_var.get(record.levelno)) is None
-                # Checks if ers_handlers (specifically for ERS) is supplied by the msg
-                or (ers_handlers := getattr(record, "ers_handlers", None)) is None
-                # _Assigns_ the relevant ERS handler conf from supplied level
-                or (ershandlerconf := ers_handlers.get(ers_level_var)) is None
-            ):
-                return None
-            
-            allowed = ershandlerconf.handlers
 
+    def get_allowed(self, record: logging.LogRecord) -> set[HandlerType] | None:
+        return self.allowed_handlers_strategy.resolve(record, self.fallback_handlers)
 
-        # Handle the non-ERS case
-        else:
-            allowed = getattr(record, "handlers", self.fallback_handlers) 
-        return allowed
         
 class HandleIDFilter(BaseHandlerFilter):
     """Filter class that accepts a list of 'allowed' handlers and will only fire
@@ -382,12 +83,14 @@ class HandleIDFilter(BaseHandlerFilter):
         self,
         handler_id: HandlerType | list[HandlerType],
         fallback_handlers: set[HandlerType] | None = None,
+        allowed_handlers_strategy: AllowedHandlersStrategy | None = None,
     ) -> None:
         """Initialises HandleIDFilter with the handler_id, to identify what
         kind of handler this filter is.
         """
         super().__init__(
-            fallback_handlers = fallback_handlers
+            fallback_handlers = fallback_handlers,
+            allowed_handlers_strategy=allowed_handlers_strategy
         )
         
         # Normalise handler_id to be a set
@@ -400,7 +103,7 @@ class HandleIDFilter(BaseHandlerFilter):
         """Identifies when a log message should be transmitted or not."""
         if not (allowed:= self.get_allowed(record)):
             return False
-        return bool(self.handler_ids & set(allowed))
+        return bool(self.handler_ids & allowed)
 
 class ThrottleFilter(BaseHandlerFilter):
     """Advanced logging filter with escalating throttle thresholds.
@@ -430,10 +133,12 @@ class ThrottleFilter(BaseHandlerFilter):
         fallback_handlers: set[HandlerType] | None = None,
         initial_threshold: int = 30,
         time_limit: int = 30,
+        allowed_handlers_strategy : AllowedHandlersStrategy | None = None
     ) -> None:
         """C'tor."""
         super().__init__(
-            fallback_handlers = fallback_handlers
+            fallback_handlers = fallback_handlers,
+            allowed_handlers_strategy = allowed_handlers_strategy
             )
         self.initial_threshold = initial_threshold
         self.time_limit = time_limit

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -919,7 +919,8 @@ def add_handlers_from_types(
             None,
             None,
             lambda: add_ers_kafka_handler(
-                log, use_parent_handlers, ers_session_name, fallback_handlers
+                log, use_parent_handlers, ers_session_name, {HandlerType.Unknown}
+                # WE DONT WANT TO TRANSMIT BY DEFAULT
             ),
         ),
         HandlerType.Throttle: (

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -250,12 +250,14 @@ def get_handler_specs(handler_type: HandlerType):
 
 def add_handler(
     log: logging.Logger,
-    handler_type: HandlerType,
+    handler_type: HandlerType | str, 
     use_parent_handlers:bool, 
-    fallback_handler: set[HandlerType] | None,
+    fallback_handler: set[HandlerType] | None = None,
     extras: Mapping[str, Any] | None = None,
-):
-    specs = get_handler_specs(handler_type) 
+):    
+    ht = HandlerType.from_string(handler_type) if isinstance(handler_type, str) else handler_type
+    specs = get_handler_specs(ht) 
+    
     for spec in specs:
         if logger_or_ancestors_have_handler(
             log,
@@ -293,83 +295,7 @@ def add_handler(
         log.addHandler(handler)
 
 
-#! Backwards compatibility. We should consider retiring these functinos
 
-def add_rich_handler(
-    log: logging.Logger,
-    use_parent_handlers: bool,
-    fallback_handlers: set[HandlerType] | None = None,
-) -> None:
-    
-    add_handler(
-        log,
-        HandlerType.Rich,
-        use_parent_handlers,
-        fallback_handlers
-    )
-
-def add_stdout_handler(
-    log: logging.Logger,
-    use_parent_handlers: bool,
-    fallback_handlers: set[HandlerType] | None = None,
-) -> None:
-    add_handler(
-        log,
-        HandlerType.Lstdout,
-        use_parent_handlers,
-        fallback_handlers
-    )
-
-def add_stderr_handler(
-    log: logging.Logger,
-    use_parent_handlers: bool,
-    fallback_handlers: set[HandlerType] | None = None,
-) -> None:
-    add_handler(
-        log,
-        HandlerType.Lstderr,
-        use_parent_handlers,
-        fallback_handlers
-    )
-
-def add_file_handler(
-    log: logging.Logger,
-    use_parent_handlers: bool,
-    path: str,
-    fallback_handlers: set[HandlerType] | None = None,
-) -> None:
-    add_handler(
-        log,
-        HandlerType.File,
-        use_parent_handlers,
-        fallback_handlers,
-        extras = {
-            "path" : path
-        }
-    )
-
-def add_ers_kafka_handler(
-    log: logging.Logger,
-    use_parent_handlers: bool,
-    session_name: str,
-    fallback_handlers: set[HandlerType] | None = None,
-    app_name : str|None =None,
-    topic: str = "ers_stream",
-    address: str = "monkafka.cern.ch:30092",
-) -> None:
-    add_handler(
-        log,
-        HandlerType.Protobufstream,
-        use_parent_handlers,
-        fallback_handlers,
-        extras={
-            "session_name": session_name,
-            "topic": topic,
-            "address": address,
-            "app_name": app_name,
-        },
-    )
-    
 def add_handlers_from_types(
     log: logging.Logger,
     handler_types: set[HandlerType],

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -276,7 +276,6 @@ class LogHandlerConf:
             converts "protobufstream(url:port)" to return both the HandlerType and the 
             protobuf configuration
         """
-        # print(f"{handler_str=}")
         if "erstrace" in handler_str:
             msg = (
                 "ERSTrace is a C++ implementation, "
@@ -299,12 +298,10 @@ class LogHandlerConf:
         """Generates the ERSPyLogHandlerConf from reading an environment variable."""
         erspyloghandlerconf = ERSPyLogHandlerConf()
         envvalue = os.getenv(ers_log_level)
-        # print(f"{envvalue=}")
         if envvalue is None:
             raise ERSEnvError(ers_log_level)
         
         for h in envvalue.split(","):
-            # print(f"{h=}")
             handlertype, kafkaconf = LogHandlerConf._convert_str_to_handlertype(h)
             erspyloghandlerconf.handlers.append(handlertype)
             if kafkaconf:
@@ -425,8 +422,6 @@ class ThrottleFilter(BaseHandlerFilter):
     
     def __init__(self, default_case=LogHandlerConf.get_base(), initial_threshold: int = 30, time_limit:  int = 30) -> None:
         """C'tor."""
-        #! THERES A BUG HERE.. WHERE IF YOU WRONGLY INITIALISE IT ITS NOT GONNA FIRE AT ALL.........
-        
         super().__init__(
             default_case = default_case
             )
@@ -577,32 +572,14 @@ def _logger_has_handler(
 
     For StreamHandler, ``target_stream`` can be used to distinguish stdout/stderr.
     """
-    #EXCEPT STREAM HANDLER YOU FOOL
+
     type_matches = [isinstance(handler, handler_type) for handler in log.handlers if not isinstance(handler, logging.StreamHandler)]
 
-    
-    stream_matches = []
-
-    # print(f"{handler_type=},{target_stream = } ")
-
-    for handler in log.handlers:
-        if isinstance(handler, logging.StreamHandler):
-            # print(f"{handler=}, {handler.stream=}")
-            if target_stream:
-                # print("Target stream")
-                if handler.stream is target_stream:
-                    # print("dice")
-                    stream_matches.append(True)
-                else:
-                    # print("no dice")
-                    stream_matches.append(False)
-            else:
-                # print("No Stream")
-                stream_matches.append(False)
-            
-    # print(f"{type_matches=}, {stream_matches=}" )
-    # print(f"outcome: {any(type_matches + stream_matches)}")
-    # print("")
+    stream_matches = [
+            handler.stream is target_stream if target_stream else False
+            for handler in log.handlers
+            if isinstance(handler, logging.StreamHandler)
+        ]
     return any(type_matches + stream_matches)
 
 def check_parent_handlers(
@@ -635,7 +612,6 @@ def check_parent_handlers(
     if log.name == python_root_logger_name:
         err_msg = "You should not be interfacing with the root logger"
         raise ValueError(err_msg)
-        
     # Validate the stream handler has a target stream
     if handler_type.__name__ == "StreamHandler" and target_stream is None:
         err_msg = (
@@ -675,12 +651,14 @@ def add_rich_handler(log: logging.Logger, use_parent_handlers: bool, default_cas
     """
     check_parent_handlers(log, use_parent_handlers, FormattedRichHandler)
     width: int = get_width()
-    handler: RichHandler = FormattedRichHandler(width=width)
-
-    #! Here you better initialise handlerid filter
+    handler: RichHandler = FormattedRichHandler(width=width)    
     
-    my_filter = HandleIDFilter(handler_id=HandlerType.Rich, default_case=default_case) # Should accept the base handlers here
-    handler.addFilter(my_filter)
+    handler.addFilter(
+        HandleIDFilter(
+            handler_id=HandlerType.Rich,
+            default_case=default_case
+            )
+    )
     log.addHandler(handler)
     return
 
@@ -694,10 +672,13 @@ def add_ers_kafka_handler(log: logging.Logger, use_parent_handlers: bool,
                                                      kafka_address = address, 
                                                      kafka_topic = topic
                                                      )
-    
-        
-    my_filter = HandleIDFilter(HandlerType.Protobufstream, default_case=default_case)
-    handler.addFilter(my_filter)
+
+    handler.addFilter(
+        HandleIDFilter(
+            handler_id=HandlerType.Protobufstream,
+            default_case=default_case
+            )
+    )
     log.addHandler(handler)
 
 def add_stdout_handler(log: logging.Logger, use_parent_handlers: bool, default_case={HandlerType.Stream, HandlerType.Lstdout}) -> None:
@@ -722,10 +703,12 @@ def add_stdout_handler(log: logging.Logger, use_parent_handlers: bool, default_c
     stdout_handler = logging.StreamHandler(sys.stdout)
     stdout_handler.setFormatter(LoggingFormatter())
     
-    # repeat ad infinitum for all handlers.... 
-    my_filter = HandleIDFilter(handler_id=[HandlerType.Stream, HandlerType.Lstdout],default_case=default_case)
-    stdout_handler.addFilter(my_filter)
-    
+    stdout_handler.addFilter(
+        HandleIDFilter(
+            handler_id=[HandlerType.Stream, HandlerType.Lstdout],
+            default_case=default_case
+            )
+    )    
     log.addHandler(stdout_handler)
     return
 
@@ -755,10 +738,12 @@ def add_stderr_handler(log: logging.Logger, use_parent_handlers: bool, default_c
     )
     stderr_handler = logging.StreamHandler(sys.stderr)
     stderr_handler.setFormatter(LoggingFormatter())
-    
-    my_filter = HandleIDFilter(handler_id=[HandlerType.Stream, HandlerType.Lstderr],default_case=default_case)
-    stderr_handler.addFilter(my_filter)
-    
+    stderr_handler.addFilter(
+        HandleIDFilter(
+            handler_id=[HandlerType.Stream, HandlerType.Lstderr],
+            default_case=default_case
+            )
+    )    
     stderr_handler.setLevel(logging.ERROR)
     log.addHandler(stderr_handler)
     return
@@ -781,10 +766,12 @@ def add_file_handler(log: logging.Logger, use_parent_handlers: bool, path: str, 
     check_parent_handlers(log, use_parent_handlers, logging.FileHandler)
     file_handler = logging.FileHandler(filename=path)
     file_handler.setFormatter(LoggingFormatter())
-    
-    my_filter = HandleIDFilter(HandlerType.File, default_case)
-    file_handler.addFilter(my_filter)
-    
+    file_handler.addFilter(
+        HandleIDFilter(
+            handler_id=HandlerType.File,
+            default_case=default_case
+            )
+    )
     log.addHandler(file_handler)
     return
 

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -7,10 +7,7 @@ from typing import Any, cast
 
 from erskafka.ERSKafkaLogHandler import ERSKafkaLogHandler
 
-from daqpytools.logging.exceptions import (
-    LoggerHandlerError,
-    ERSInitError
-)
+from daqpytools.logging.exceptions import ERSInitError, LoggerHandlerError
 from daqpytools.logging.filters import (
     HandleIDFilter,
     add_filter,
@@ -156,10 +153,10 @@ def _build_rich_handler(width: int | None = None, **_: Any) -> logging.Handler:
     return FormattedRichHandler(width=real_width)
 
 RICH_HANDLER_SPEC = HandlerSpec(
-    representative_type = HandlerType.Rich,
-    handler_type = FormattedRichHandler,
+    alias = HandlerType.Rich,
+    handler_class = FormattedRichHandler,
     factory=_build_rich_handler,
-    filter_handler_ids = (HandlerType.Rich,), # For HandleIDFilter
+    fallback_types = (HandlerType.Rich,), # For HandleIDFilter
 )
 
 def _build_stdout_handler(**_: Any) -> logging.Handler:
@@ -168,11 +165,11 @@ def _build_stdout_handler(**_: Any) -> logging.Handler:
     return handler
 
 STDOUT_HANDLER_SPEC = HandlerSpec(
-    representative_type = HandlerType.Lstdout,
-    handler_type = logging.StreamHandler,
+    alias = HandlerType.Lstdout,
+    handler_class = logging.StreamHandler,
     target_stream=cast(io.IOBase, sys.stdout),
     factory=_build_stdout_handler,
-    filter_handler_ids = (HandlerType.Stream, HandlerType.Lstdout),
+    fallback_types = (HandlerType.Stream, HandlerType.Lstdout),
 )
 
 def _build_stderr_handler(**_: Any) -> logging.Handler:
@@ -182,11 +179,11 @@ def _build_stderr_handler(**_: Any) -> logging.Handler:
     return handler
 
 STDERR_HANDLER_SPEC = HandlerSpec(
-    representative_type = HandlerType.Lstderr,
-    handler_type = logging.StreamHandler,
+    alias = HandlerType.Lstderr,
+    handler_class = logging.StreamHandler,
     target_stream=cast(io.IOBase, sys.stderr),
     factory=_build_stderr_handler,
-    filter_handler_ids = (HandlerType.Stream, HandlerType.Lstderr),
+    fallback_types = (HandlerType.Stream, HandlerType.Lstderr),
 )
 
 def _build_file_handler(path: str | None = None, **_: Any) -> logging.Handler:
@@ -199,10 +196,10 @@ def _build_file_handler(path: str | None = None, **_: Any) -> logging.Handler:
     return handler
 
 FILE_HANDLER_SPEC = HandlerSpec(
-    representative_type=HandlerType.File,
-    handler_type = logging.FileHandler,
+    alias=HandlerType.File,
+    handler_class = logging.FileHandler,
     factory = _build_file_handler,
-    filter_handler_ids=(HandlerType.File,)
+    fallback_types=(HandlerType.File,)
 )
 
 def _build_erskafka_handler(
@@ -224,10 +221,10 @@ def _build_erskafka_handler(
 
     
 ERSKAFKA_HANDLER_SPEC = HandlerSpec(
-    representative_type=HandlerType.Protobufstream,
-    handler_type = ERSKafkaLogHandler,
+    alias=HandlerType.Protobufstream,
+    handler_class = ERSKafkaLogHandler,
     factory = _build_erskafka_handler,
-    filter_handler_ids=[HandlerType.Protobufstream],
+    fallback_types=(HandlerType.Protobufstream,),
 )
 
 
@@ -260,7 +257,7 @@ def add_handler(
         if logger_or_ancestors_have_handler(
             log,
             use_parent_handlers,
-            spec.handler_type,
+            spec.handler_class,
             target_stream=spec.target_stream,
         ):
             continue
@@ -269,18 +266,18 @@ def add_handler(
         check_parent_handlers(
             log,
             use_parent_handlers,
-            spec.handler_type,
+            spec.handler_class,
             target_stream = spec.target_stream
         )
 
         handler = spec.factory(**extras)
-        effective_default_case = fallback_handler if fallback_handler is not None else spec.filter_handler_ids
+        effective_default_case = fallback_handler if fallback_handler is not None else spec.fallback_types
 
         handler_ids: HandlerType | list[HandlerType]
-        if len(spec.filter_handler_ids) == 1:
-            handler_ids = cast(HandlerType, spec.filter_handler_ids[0])
+        if len(spec.fallback_types) == 1:
+            handler_ids = cast(HandlerType, spec.fallback_types[0])
         else: 
-            handler_ids = [cast(HandlerType, handler_id) for handler_id in spec.filter_handler_ids] 
+            handler_ids = [cast(HandlerType, handler_id) for handler_id in spec.fallback_types] 
  
         handler.addFilter(
             HandleIDFilter(
@@ -323,5 +320,5 @@ def add_handlers_from_types(
             continue
 
         filter_spec = get_filter_spec(handler_type)
-        if filter_spec and not logger_has_filter(log, filter_spec.filter_type):
+        if filter_spec and not logger_has_filter(log, filter_spec.filter_class):
             add_filter(log, handler_type, fallback_handlers, **extras)

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -8,6 +8,7 @@ import re
 import sys
 import time
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -193,7 +194,6 @@ class ERSPyLogHandlerConf:
     handlers: list = field(default_factory = lambda: [])
     protobufconf: ProtobufConf = field(default_factory = lambda: None)
 
-#! TODO/now= consider @dataclass(frozen=True)
 @dataclass
 class LogHandlerConf:
     """Dataclass that holds the various streams and relevant handlers.
@@ -342,8 +342,10 @@ class BaseHandlerFilter(logging.Filter):
     """Base filter that hold the logic on choosing if a handler should emit
     based on what HandlersTypes are supplied to it.
     """
-    def __init__(self, default_case = LogHandlerConf.get_base() ) -> None:
+    def __init__(self, default_case: set[HandlerType] | None = None) -> None:
         """C'tor."""
+        if default_case is None:
+            default_case = set(LogHandlerConf.get_base())
         self.default_case = default_case
         super().__init__()
     
@@ -377,7 +379,11 @@ class HandleIDFilter(BaseHandlerFilter):
     if the current handler (defined by the handler_id) is within the set of 
     allowed handlers.
     """
-    def __init__(self, handler_id: HandlerType | list[HandlerType], default_case = LogHandlerConf.get_base()) -> None:
+    def __init__(
+        self,
+        handler_id: HandlerType | list[HandlerType],
+        default_case: set[HandlerType] | None = None,
+    ) -> None:
         """Initialises HandleIDFilter with the handler_id, to identify what
         kind of handler this filter is.
         """
@@ -420,7 +426,12 @@ class ThrottleFilter(BaseHandlerFilter):
         ...     logger.error("Repeated error message")
     """
     
-    def __init__(self, default_case=LogHandlerConf.get_base(), initial_threshold: int = 30, time_limit:  int = 30) -> None:
+    def __init__(
+        self,
+        default_case: set[HandlerType] | None = None,
+        initial_threshold: int = 30,
+        time_limit: int = 30,
+    ) -> None:
         """C'tor."""
         super().__init__(
             default_case = default_case
@@ -551,15 +562,22 @@ class ThrottleFilter(BaseHandlerFilter):
         return Text(time_str, style="logging.time")
     
 
-def add_throttle_filter(log: logging.Logger, default_case = {HandlerType.Throttle}) -> None:
+def add_throttle_filter(
+    log: logging.Logger,
+    default_case: set[HandlerType] | None = None,
+) -> None:
     """Add the Throttle filter to the logger.
 
     Args:
         log (logging.Logger): Logger to add the rich handler to.
+        default_case (set[HandlerType] | None): Default handler set used when
+            records do not explicitly include handler routing.
 
     Returns:
         None
     """
+    if default_case is None:
+        default_case = {HandlerType.Throttle}
     log.addFilter(ThrottleFilter(default_case=default_case))
     return
 
@@ -572,8 +590,11 @@ def _logger_has_handler(
 
     For StreamHandler, ``target_stream`` can be used to distinguish stdout/stderr.
     """
-
-    type_matches = [isinstance(handler, handler_type) for handler in log.handlers if not isinstance(handler, logging.StreamHandler)]
+    type_matches = [
+        isinstance(handler, handler_type)
+        for handler in log.handlers
+        if not isinstance(handler, logging.StreamHandler)
+    ]
 
     stream_matches = [
             handler.stream is target_stream if target_stream else False
@@ -636,12 +657,18 @@ def check_parent_handlers(
     return
 
 
-def add_rich_handler(log: logging.Logger, use_parent_handlers: bool, default_case={HandlerType.Rich}) -> None:
+def add_rich_handler(
+    log: logging.Logger,
+    use_parent_handlers: bool,
+    default_case: set[HandlerType] | None = None,
+) -> None:
     """Add a rich handler to the logger.
 
     Args:
         log (logging.Logger): Logger to add the rich handler to.
         use_parent_handlers (bool): Whether to check parent handlers.
+        default_case (set[HandlerType] | None): Default handler set used when
+            records do not explicitly include handler routing.
 
     Returns:
         None
@@ -649,6 +676,8 @@ def add_rich_handler(log: logging.Logger, use_parent_handlers: bool, default_cas
     Raises:
         LoggerHandlerError: If a parent logger has a rich handler.
     """
+    if default_case is None:
+        default_case = {HandlerType.Rich}
     check_parent_handlers(log, use_parent_handlers, FormattedRichHandler)
     width: int = get_width()
     handler: RichHandler = FormattedRichHandler(width=width)    
@@ -662,11 +691,18 @@ def add_rich_handler(log: logging.Logger, use_parent_handlers: bool, default_cas
     log.addHandler(handler)
     return
 
-def add_ers_kafka_handler(log: logging.Logger, use_parent_handlers: bool,
-                                 session_name:str, default_case = {HandlerType.Protobufstream}, topic: str = "ers_stream", 
-                                 address: str ="monkafka.cern.ch:30092") -> None:
+def add_ers_kafka_handler(
+    log: logging.Logger,
+    use_parent_handlers: bool,
+    session_name: str,
+    default_case: set[HandlerType] | None = None,
+    topic: str = "ers_stream",
+    address: str = "monkafka.cern.ch:30092",
+) -> None:
     # TODO/future: topic and address are new, propagate to all relevant implementation
     """Add an ers protobuf handler to the root logger."""
+    if default_case is None:
+        default_case = {HandlerType.Protobufstream}
     check_parent_handlers(log, use_parent_handlers, ERSKafkaLogHandler)
     handler: ERSKafkaLogHandler = ERSKafkaLogHandler(session=session_name, 
                                                      kafka_address = address, 
@@ -681,12 +717,18 @@ def add_ers_kafka_handler(log: logging.Logger, use_parent_handlers: bool,
     )
     log.addHandler(handler)
 
-def add_stdout_handler(log: logging.Logger, use_parent_handlers: bool, default_case={HandlerType.Stream, HandlerType.Lstdout}) -> None:
+def add_stdout_handler(
+    log: logging.Logger,
+    use_parent_handlers: bool,
+    default_case: set[HandlerType] | None = None,
+) -> None:
     """Add a stdout handler to the logger.
 
     Args:
         log (logging.Logger): Logger to add the stdout handler to.
         use_parent_handlers (bool): Whether to check parent handlers.
+        default_case (set[HandlerType] | None): Default handler set used when
+            records do not explicitly include handler routing.
 
     Returns:
         None
@@ -694,6 +736,8 @@ def add_stdout_handler(log: logging.Logger, use_parent_handlers: bool, default_c
     Raises:
         LoggerHandlerError: If a parent logger has a stdout handler.
     """
+    if default_case is None:
+        default_case = {HandlerType.Stream, HandlerType.Lstdout}
     check_parent_handlers(
         log,
         use_parent_handlers,
@@ -712,8 +756,11 @@ def add_stdout_handler(log: logging.Logger, use_parent_handlers: bool, default_c
     log.addHandler(stdout_handler)
     return
 
-# Consider seeing if there is a way to generalify the add X handler..
-def add_stderr_handler(log: logging.Logger, use_parent_handlers: bool, default_case={HandlerType.Lstderr, HandlerType.Stream}) -> None:
+def add_stderr_handler(
+    log: logging.Logger,
+    use_parent_handlers: bool,
+    default_case: set[HandlerType] | None = None,
+) -> None:
     """Add a stderr handler to the logger.
 
     The error is set to the ERROR level, and will only log messages at that level
@@ -723,6 +770,8 @@ def add_stderr_handler(log: logging.Logger, use_parent_handlers: bool, default_c
     Args:
         log (logging.Logger): Logger to add the stderr handler to.
         use_parent_handlers (bool): Whether to check parent handlers.
+        default_case (set[HandlerType] | None): Default handler set used when
+            records do not explicitly include handler routing.
 
     Returns:
         None
@@ -730,6 +779,8 @@ def add_stderr_handler(log: logging.Logger, use_parent_handlers: bool, default_c
     Raises:
         LoggerHandlerError: If a parent logger has a stderr handler.
     """
+    if default_case is None:
+        default_case = {HandlerType.Lstderr, HandlerType.Stream}
     check_parent_handlers(
         log,
         use_parent_handlers,
@@ -749,13 +800,20 @@ def add_stderr_handler(log: logging.Logger, use_parent_handlers: bool, default_c
     return
 
 
-def add_file_handler(log: logging.Logger, use_parent_handlers: bool, path: str, default_case={HandlerType.File}) -> None:
+def add_file_handler(
+    log: logging.Logger,
+    use_parent_handlers: bool,
+    path: str,
+    default_case: set[HandlerType] | None = None,
+) -> None:
     """Add a file handler to the root logger.
 
     Args:
         log (logging.Logger): Logger to add the file handler to.
         use_parent_handlers (bool): Whether to check parent handlers.
         path (str): Path to the log file.
+        default_case (set[HandlerType] | None): Default handler set used when
+            records do not explicitly include handler routing.
 
     Returns:
         None
@@ -763,6 +821,8 @@ def add_file_handler(log: logging.Logger, use_parent_handlers: bool, path: str, 
     Raises:
         LoggerHandlerError: If a parent logger has a file handler.
     """
+    if default_case is None:
+        default_case = {HandlerType.File}
     check_parent_handlers(log, use_parent_handlers, logging.FileHandler)
     file_handler = logging.FileHandler(filename=path)
     file_handler.setFormatter(LoggingFormatter())
@@ -784,7 +844,10 @@ def _logger_has_filter(log: logging.Logger, filter_type: type[logging.Filter]) -
 def add_handlers_from_types(
     log: logging.Logger,
     handler_types: set[HandlerType],
+    use_parent_handlers: bool,
+    file_name: str | None,
     ers_session_name: str | None,
+    default_case: set[HandlerType],
 ) -> None:
     """Add handlers to a logger based on a set of HandlerType values.
 
@@ -793,14 +856,12 @@ def add_handlers_from_types(
     - ``HandlerType.File`` is not supported and raises immediately.
     - ``HandlerType.Protobufstream`` requires ``ers_session_name``.
     """
-
-    default_case = {HandlerType.Unknown}
-    if HandlerType.File in handler_types:
-        err_msg = "HandlerType.File is not supported by add_handlers_from_types"
-        raise ValueError(err_msg)
-
     if HandlerType.Protobufstream in handler_types and not ers_session_name:
         err_msg = "ers_session_name is required for HandlerType.Protobufstream"
+        raise ValueError(err_msg)
+    
+    if HandlerType.File in handler_types and not file_name:
+        err_msg = "file_name is required for HandlerType.File"
         raise ValueError(err_msg)
 
     # Update relevant handler types that was parsed
@@ -822,7 +883,6 @@ def add_handlers_from_types(
         else None,
     }
     existing_stream_handlers.discard(None)
-    print(f"{existing_stream_handlers=}")
 
     # Check if current logger has the interested handler
     existing_handlers = {
@@ -831,29 +891,38 @@ def add_handlers_from_types(
         if _logger_has_handler(log, ERSKafkaLogHandler)
         else None,
         HandlerType.Throttle if _logger_has_filter(log, ThrottleFilter) else None,
+        HandlerType.File if _logger_has_filter(log, logging.FileHandler) else None,
     }
     existing_handlers.discard(None)
     existing_handlers.update(existing_stream_handlers)
 
-    # print(f"{existing_handlers=}")
-    # print(f"{effective_handler_types=}")
-
-    handlers_init_map = {
-        HandlerType.Rich: lambda: add_rich_handler(log, True, default_case),
-        HandlerType.Lstdout: lambda: add_stdout_handler(log, True, default_case),
-        HandlerType.Lstderr: lambda: add_stderr_handler(log, True, default_case),
-        HandlerType.Protobufstream: lambda: add_ers_kafka_handler(
-            log, True, ers_session_name, default_case
+    handlers_init_map: dict[HandlerType, Callable[[], None]] = {
+        HandlerType.Rich: lambda: add_rich_handler(
+            log, use_parent_handlers, default_case
         ),
-        HandlerType.Throttle: lambda: add_throttle_filter(log, {HandlerType.Rich})
+        HandlerType.Lstdout: lambda: add_stdout_handler(
+            log, use_parent_handlers, default_case
+        ),
+        HandlerType.Lstderr: lambda: add_stderr_handler(
+            log, use_parent_handlers, default_case
+        ),
+        HandlerType.File: lambda: add_file_handler(
+            log, use_parent_handlers, file_name, default_case
+        ),
+        HandlerType.Protobufstream: lambda: add_ers_kafka_handler(
+            log, use_parent_handlers, ers_session_name, default_case
+        ),
+        HandlerType.Throttle: lambda: add_throttle_filter(log, default_case),
     }
 
+    # Need to clean this bit up
     supported_handers = [
         HandlerType.Rich,
         HandlerType.Lstdout,
         HandlerType.Lstderr,
         HandlerType.Protobufstream,
         HandlerType.Throttle,
+        HandlerType.File,
     ]
 
     for handler_type in supported_handers:
@@ -864,7 +933,5 @@ def add_handlers_from_types(
         installer = handlers_init_map.get(handler_type)
         if installer is None:
             continue
-        print(handler_type)
-
         installer()
 

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import logging
 import sys
-from typing import Any, cast
+from typing import cast
 
 from erskafka.ERSKafkaLogHandler import ERSKafkaLogHandler
 
@@ -147,7 +147,7 @@ def logger_or_ancestors_have_handler(
 
 #### Handlers #### 
 
-def _build_rich_handler(width: int | None = None, **_: Any) -> logging.Handler:
+def _build_rich_handler(width: int | None = None, **_: object) -> logging.Handler:
     """Building the rich handler with any extras."""
     real_width = width if width is not None else get_width()
     return FormattedRichHandler(width=real_width)
@@ -159,7 +159,7 @@ RICH_HANDLER_SPEC = HandlerSpec(
     fallback_types = (HandlerType.Rich,), # For HandleIDFilter
 )
 
-def _build_stdout_handler(**_: Any) -> logging.Handler:
+def _build_stdout_handler(**_: object) -> logging.Handler:
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(LoggingFormatter())
     return handler
@@ -172,7 +172,7 @@ STDOUT_HANDLER_SPEC = HandlerSpec(
     fallback_types = (HandlerType.Stream, HandlerType.Lstdout),
 )
 
-def _build_stderr_handler(**_: Any) -> logging.Handler:
+def _build_stderr_handler(**_: object) -> logging.Handler:
     handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(LoggingFormatter())
     handler.setLevel(logging.ERROR)
@@ -186,7 +186,7 @@ STDERR_HANDLER_SPEC = HandlerSpec(
     fallback_types = (HandlerType.Stream, HandlerType.Lstderr),
 )
 
-def _build_file_handler(path: str | None = None, **_: Any) -> logging.Handler:
+def _build_file_handler(path: str | None = None, **_: object) -> logging.Handler:
     if not path:
         err_msg = "path is required for file handler"
         raise ValueError(err_msg)
@@ -207,7 +207,7 @@ def _build_erskafka_handler(
         topic : str = "ers_stream",
         address : str = "monkafka.cern.ch:30092",
         ers_app_name : str | None = None,
-        **_) -> logging.Handler: 
+    **_: object) -> logging.Handler: 
     
     try:
         return ERSKafkaLogHandler(
@@ -216,8 +216,8 @@ def _build_erskafka_handler(
             kafka_topic = topic,
             app_name=ers_app_name
         )
-    except:
-        raise ERSInitError(address, topic)
+    except Exception as err:
+        raise ERSInitError(address, topic) from err
 
     
 ERSKAFKA_HANDLER_SPEC = HandlerSpec(
@@ -239,18 +239,23 @@ HANDLER_SPEC_REGISTRY : dict[HandlerType, tuple[HandlerSpec, ...]] = {
     HandlerType.Protobufstream: (ERSKAFKA_HANDLER_SPEC,)
 }
 
-def get_handler_specs(handler_type: HandlerType):
-    """Get the specs defined in the registry"""
-    return HANDLER_SPEC_REGISTRY.get(handler_type, tuple())
+def get_handler_specs(handler_type: HandlerType) -> tuple[HandlerSpec, ...]:
+    """Get the specs defined in the registry."""
+    return HANDLER_SPEC_REGISTRY.get(handler_type, ())
 
 def add_handler(
     log: logging.Logger,
     handler_type: HandlerType | str, 
     use_parent_handlers:bool, 
     fallback_handler: set[HandlerType] | None = None,
-    **extras: Any
-):    
-    ht = HandlerType.from_string(handler_type) if isinstance(handler_type, str) else handler_type
+    **extras: object
+ ) -> None:
+    """Add a handler to the logger from the handler spec registry."""
+    ht = (
+        HandlerType.from_string(handler_type)
+        if isinstance(handler_type, str)
+        else handler_type
+    )
     specs = get_handler_specs(ht) 
     
     for spec in specs:
@@ -271,13 +276,20 @@ def add_handler(
         )
 
         handler = spec.factory(**extras)
-        effective_default_case = fallback_handler if fallback_handler is not None else spec.fallback_types
+        effective_default_case = (
+            fallback_handler
+            if fallback_handler is not None
+            else spec.fallback_types
+        )
 
         handler_ids: HandlerType | list[HandlerType]
         if len(spec.fallback_types) == 1:
             handler_ids = cast(HandlerType, spec.fallback_types[0])
         else: 
-            handler_ids = [cast(HandlerType, handler_id) for handler_id in spec.fallback_types] 
+            handler_ids = [
+                cast(HandlerType, handler_id)
+                for handler_id in spec.fallback_types
+            ] 
  
         handler.addFilter(
             HandleIDFilter(
@@ -294,7 +306,7 @@ def add_handlers_from_types(
     handler_types: set[HandlerType],
     use_parent_handlers: bool,
     fallback_handlers: set[HandlerType],
-    **extras: Any,
+    **extras: object,
 ) -> None:
     """Add handlers and filters from a set of HandlerType values.
 

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -275,6 +275,7 @@ class LogHandlerConf:
             converts "protobufstream(url:port)" to return both the HandlerType and the 
             protobuf configuration
         """
+        # print(f"{handler_str=}")
         if "erstrace" in handler_str:
             msg = (
                 "ERSTrace is a C++ implementation, "
@@ -297,10 +298,12 @@ class LogHandlerConf:
         """Generates the ERSPyLogHandlerConf from reading an environment variable."""
         erspyloghandlerconf = ERSPyLogHandlerConf()
         envvalue = os.getenv(ers_log_level)
+        # print(f"{envvalue=}")
         if envvalue is None:
             raise ERSEnvError(ers_log_level)
         
         for h in envvalue.split(","):
+            # print(f"{h=}")
             handlertype, kafkaconf = LogHandlerConf._convert_str_to_handlertype(h)
             erspyloghandlerconf.handlers.append(handlertype)
             if kafkaconf:
@@ -543,6 +546,19 @@ class ThrottleFilter(BaseHandlerFilter):
         padding: int = LOG_RECORD_PADDING.get("time", 25)
         time_str: str = dt.strftime(DATE_TIME_BASE_FORMAT).ljust(padding)[:padding]
         return Text(time_str, style="logging.time")
+    
+
+def add_throttle_filter(log: logging.Logger) -> None:
+    """Add the Throttle filter to the logger.
+
+    Args:
+        log (logging.Logger): Logger to add the rich handler to.
+
+    Returns:
+        None
+    """
+    log.addFilter(ThrottleFilter())
+    return
 
 def check_parent_handlers(
     log: logging.Logger,
@@ -716,4 +732,106 @@ def add_file_handler(log: logging.Logger, use_parent_handlers: bool, path: str) 
     file_handler.addFilter(HandleIDFilter(HandlerType.File))
     log.addHandler(file_handler)
     return
+
+
+def _logger_has_handler(
+    log: logging.Logger,
+    handler_type: type[logging.Handler],
+    target_stream: io.IOBase | None = None,
+) -> bool:
+    """Check if logger already has a matching handler.
+
+    For StreamHandler, ``target_stream`` can be used to distinguish stdout/stderr.
+    """
+    type_matches = [isinstance(handler, handler_type) for handler in log.handlers]
+    stream_matches = [
+        handler.stream is target_stream if target_stream else False
+        for handler in log.handlers
+        if isinstance(handler, logging.StreamHandler)
+    ]
+    return any(type_matches + stream_matches)
+
+
+def _logger_has_filter(log: logging.Logger, filter_type: type[logging.Filter]) -> bool:
+    """Check if logger already has a matching filter type."""
+    return any(isinstance(logger_filter, filter_type) for logger_filter in log.filters)
+
+
+def add_handlers_from_types(
+    log: logging.Logger,
+    handler_types: set[HandlerType],
+    ers_session_name: str | None,
+) -> None:
+    """Add handlers to a logger based on HandlerType values.
+
+    This helper intentionally supports only the default options for now:
+    - ``use_parent_handlers`` is always True.
+    - ``HandlerType.File`` is not supported and raises immediately.
+    - ``HandlerType.Protobufstream`` requires ``ers_session_name``.
+    """
+    if HandlerType.File in handler_types:
+        err_msg = "HandlerType.File is not supported by add_handlers_from_types"
+        raise ValueError(err_msg)
+
+    if HandlerType.Protobufstream in handler_types and not ers_session_name:
+        err_msg = "ers_session_name is required for HandlerType.Protobufstream"
+        raise ValueError(err_msg)
+
+    effective_handler_types = set(handler_types)
+    if HandlerType.Stream in effective_handler_types:
+        effective_handler_types.update({HandlerType.Lstdout, HandlerType.Lstderr})
+
+    existing_stream_handlers = {
+        HandlerType.Lstdout
+        if _logger_has_handler(
+            log, logging.StreamHandler, target_stream=cast(io.IOBase, sys.stdout)
+        )
+        else None,
+        HandlerType.Lstderr
+        if _logger_has_handler(
+            log, logging.StreamHandler, target_stream=cast(io.IOBase, sys.stderr)
+        )
+        else None,
+    }
+    existing_stream_handlers.discard(None)
+
+    existing_handlers = {
+        HandlerType.Rich if _logger_has_handler(log, FormattedRichHandler) else None,
+        HandlerType.Protobufstream
+        if _logger_has_handler(log, ERSKafkaLogHandler)
+        else None,
+        HandlerType.Throttle if _logger_has_filter(log, ThrottleFilter) else None,
+    }
+    existing_handlers.discard(None)
+    existing_handlers.update(existing_stream_handlers)
+
+    dispatch = {
+        HandlerType.Rich: lambda: add_rich_handler(log, True),
+        HandlerType.Lstdout: lambda: add_stdout_handler(log, True),
+        HandlerType.Lstderr: lambda: add_stderr_handler(log, True),
+        HandlerType.Protobufstream: lambda: add_ers_kafka_handler(
+            log, True, ers_session_name
+        ),
+        HandlerType.Throttle: lambda: add_throttle_filter(log)
+    }
+
+    #! Try to revisit this logic
+
+    install_order = [
+        HandlerType.Rich,
+        HandlerType.Lstdout,
+        HandlerType.Lstderr,
+        HandlerType.Protobufstream,
+        HandlerType.Throttle,
+    ]
+
+    for handler_type in install_order:
+        if handler_type not in effective_handler_types:
+            continue
+        if handler_type in existing_handlers:
+            continue
+        installer = dispatch.get(handler_type)
+        if installer is None:
+            continue
+        installer()
 

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -215,13 +215,39 @@ STDERR_HANDLER_SPEC = HandlerSpec(
 
 
 
+def _build_file_handler(extras: Mapping[str, Any]) -> logging.Handler:
+    path = cast(str | None, extras.get("path"))
+    if not path:
+        err_msg = "path is requiired for file handler"
+        raise ValueError(err_msg)
+    handler = logging.FileHandler(filename=path)
+    handler.setFormatter(LoggingFormatter())
+
+    return handler
+
+FILE_HANDLER_SPEC = HandlerSpec(
+    representative_type=HandlerType.File,
+    handler_type = logging.FileHandler,
+    factory = _build_file_handler,
+    filter_handler_ids=(HandlerType.File,)
+)
+
+
+
+
+
+
+
+
+
+
+
 HANDLER_SPEC_REGISTRY : dict[HandlerType, tuple[HandlerSpec, ...]] = {
     HandlerType.Rich: (RICH_HANDLER_SPEC,),
     HandlerType.Lstdout: (STDOUT_HANDLER_SPEC,),
     HandlerType.Lstderr: (STDERR_HANDLER_SPEC,),
     HandlerType.Stream: (STDOUT_HANDLER_SPEC,STDERR_HANDLER_SPEC),
-    
-    # Try stream next
+    HandlerType.File: (FILE_HANDLER_SPEC,)
 }
 
 def get_handler_specs(handler_type: HandlerType):
@@ -308,6 +334,23 @@ def add_stderr_handler(
         fallback_handlers
     )
 
+def add_file_handler(
+    log: logging.Logger,
+    use_parent_handlers: bool,
+    path: str,
+    fallback_handlers: set[HandlerType] | None = None,
+) -> None:
+    add_handler(
+        log,
+        HandlerType.File,
+        use_parent_handlers,
+        fallback_handlers,
+        extras = {
+            "path" : path
+        }
+    )
+    
+
 from daqpytools.logging.filters import add_throttle_filter
 
 ##################################################################################################
@@ -346,16 +389,18 @@ def add_ers_kafka_handler(
     )
     log.addHandler(handler)
 
-# def add_stdout_handler(
+# def add_file_handler(
 #     log: logging.Logger,
 #     use_parent_handlers: bool,
+#     path: str,
 #     fallback_handlers: set[HandlerType] | None = None,
 # ) -> None:
-#     """Add a stdout handler to the logger.
+#     """Add a file handler to the root logger.
 
 #     Args:
-#         log (logging.Logger): Logger to add the stdout handler to.
+#         log (logging.Logger): Logger to add the file handler to.
 #         use_parent_handlers (bool): Whether to check parent handlers.
+#         path (str): Path to the log file.
 #         fallback_handlers (set[HandlerType] | None): Default handler set used when
 #             records do not explicitly include handler routing.
 
@@ -363,107 +408,21 @@ def add_ers_kafka_handler(
 #         None
 
 #     Raises:
-#         LoggerHandlerError: If a parent logger has a stdout handler.
+#         LoggerHandlerError: If a parent logger has a file handler.
 #     """
 #     if fallback_handlers is None:
-#         fallback_handlers = {HandlerType.Stream, HandlerType.Lstdout}
-#     check_parent_handlers(
-#         log,
-#         use_parent_handlers,
-#         logging.StreamHandler,
-#         target_stream=cast(io.IOBase, sys.stdout),
-#     )
-#     stdout_handler = logging.StreamHandler(sys.stdout)
-#     stdout_handler.setFormatter(LoggingFormatter())
-    
-#     stdout_handler.addFilter(
+#         fallback_handlers = {HandlerType.File}
+#     check_parent_handlers(log, use_parent_handlers, logging.FileHandler)
+#     file_handler = logging.FileHandler(filename=path)
+#     file_handler.setFormatter(LoggingFormatter())
+#     file_handler.addFilter(
 #         HandleIDFilter(
-#             handler_id=[HandlerType.Stream, HandlerType.Lstdout],
+#             handler_id=HandlerType.File,
 #             fallback_handlers=fallback_handlers
 #             )
-#     )    
-#     log.addHandler(stdout_handler)
-#     return
-
-# def add_stderr_handler(
-#     log: logging.Logger,
-#     use_parent_handlers: bool,
-#     fallback_handlers: set[HandlerType] | None = None,
-# ) -> None:
-#     """Add a stderr handler to the logger.
-
-#     The error is set to the ERROR level, and will only log messages at that level
-#     or higher. This is to avoid duplicate logging of error messages when both stdout
-#     and stderr handlers are used.
-
-#     Args:
-#         log (logging.Logger): Logger to add the stderr handler to.
-#         use_parent_handlers (bool): Whether to check parent handlers.
-#         fallback_handlers (set[HandlerType] | None): Default handler set used when
-#             records do not explicitly include handler routing.
-
-#     Returns:
-#         None
-
-#     Raises:
-#         LoggerHandlerError: If a parent logger has a stderr handler.
-#     """
-#     if fallback_handlers is None:
-#         fallback_handlers = {HandlerType.Lstderr, HandlerType.Stream}
-#     check_parent_handlers(
-#         log,
-#         use_parent_handlers,
-#         logging.StreamHandler,
-#         target_stream=cast(io.IOBase, sys.stderr),
 #     )
-#     stderr_handler = logging.StreamHandler(sys.stderr)
-#     stderr_handler.setFormatter(LoggingFormatter())
-#     stderr_handler.addFilter(
-#         HandleIDFilter(
-#             handler_id=[HandlerType.Stream, HandlerType.Lstderr],
-#             fallback_handlers=fallback_handlers
-#             )
-#     )    
-#     stderr_handler.setLevel(logging.ERROR)
-#     log.addHandler(stderr_handler)
+#     log.addHandler(file_handler)
 #     return
-
-
-
-def add_file_handler(
-    log: logging.Logger,
-    use_parent_handlers: bool,
-    path: str,
-    fallback_handlers: set[HandlerType] | None = None,
-) -> None:
-    """Add a file handler to the root logger.
-
-    Args:
-        log (logging.Logger): Logger to add the file handler to.
-        use_parent_handlers (bool): Whether to check parent handlers.
-        path (str): Path to the log file.
-        fallback_handlers (set[HandlerType] | None): Default handler set used when
-            records do not explicitly include handler routing.
-
-    Returns:
-        None
-
-    Raises:
-        LoggerHandlerError: If a parent logger has a file handler.
-    """
-    if fallback_handlers is None:
-        fallback_handlers = {HandlerType.File}
-    check_parent_handlers(log, use_parent_handlers, logging.FileHandler)
-    file_handler = logging.FileHandler(filename=path)
-    file_handler.setFormatter(LoggingFormatter())
-    file_handler.addFilter(
-        HandleIDFilter(
-            handler_id=HandlerType.File,
-            fallback_handlers=fallback_handlers
-            )
-    )
-    log.addHandler(file_handler)
-    return
 
 
 

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -337,16 +337,15 @@ class IssueRecord:
         self.suppressed_counter: int = 0
         self.last_occurrence_formatted: str = ""
 
-
 class BaseHandlerFilter(logging.Filter):
     """Base filter that hold the logic on choosing if a handler should emit
     based on what HandlersTypes are supplied to it.
     """
-    def __init__(self, default_case: set[HandlerType] | None = None) -> None:
+    def __init__(self, fallback_handlers: set[HandlerType] | None = None) -> None:
         """C'tor."""
-        if default_case is None:
-            default_case = set(LogHandlerConf.get_base())
-        self.default_case = default_case
+        if fallback_handlers is None:
+            fallback_handlers = set(LogHandlerConf.get_base())
+        self.fallback_handlers = fallback_handlers
         super().__init__()
     
     def get_allowed(self, record: logging.LogRecord) -> list | None:
@@ -371,7 +370,7 @@ class BaseHandlerFilter(logging.Filter):
 
         # Handle the non-ERS case
         else:
-            allowed = getattr(record, "handlers", self.default_case) 
+            allowed = getattr(record, "handlers", self.fallback_handlers) 
         return allowed
         
 class HandleIDFilter(BaseHandlerFilter):
@@ -382,13 +381,13 @@ class HandleIDFilter(BaseHandlerFilter):
     def __init__(
         self,
         handler_id: HandlerType | list[HandlerType],
-        default_case: set[HandlerType] | None = None,
+        fallback_handlers: set[HandlerType] | None = None,
     ) -> None:
         """Initialises HandleIDFilter with the handler_id, to identify what
         kind of handler this filter is.
         """
         super().__init__(
-            default_case = default_case
+            fallback_handlers = fallback_handlers
         )
         
         # Normalise handler_id to be a set
@@ -428,13 +427,13 @@ class ThrottleFilter(BaseHandlerFilter):
     
     def __init__(
         self,
-        default_case: set[HandlerType] | None = None,
+        fallback_handlers: set[HandlerType] | None = None,
         initial_threshold: int = 30,
         time_limit: int = 30,
     ) -> None:
         """C'tor."""
         super().__init__(
-            default_case = default_case
+            fallback_handlers = fallback_handlers
             )
         self.initial_threshold = initial_threshold
         self.time_limit = time_limit
@@ -561,27 +560,7 @@ class ThrottleFilter(BaseHandlerFilter):
         time_str: str = dt.strftime(DATE_TIME_BASE_FORMAT).ljust(padding)[:padding]
         return Text(time_str, style="logging.time")
     
-
-def add_throttle_filter(
-    log: logging.Logger,
-    default_case: set[HandlerType] | None = None,
-) -> None:
-    """Add the Throttle filter to the logger.
-
-    Args:
-        log (logging.Logger): Logger to add the rich handler to.
-        default_case (set[HandlerType] | None): Default handler set used when
-            records do not explicitly include handler routing.
-
-    Returns:
-        None
-    """
-    if default_case is None:
-        default_case = {HandlerType.Throttle}
-    log.addFilter(ThrottleFilter(default_case=default_case))
-    return
-
-def _logger_has_handler(
+def logger_has_handler(
     log: logging.Logger,
     handler_type: type[logging.Handler],
     target_stream: io.IOBase | None = None,
@@ -602,6 +581,10 @@ def _logger_has_handler(
             if isinstance(handler, logging.StreamHandler)
         ]
     return any(type_matches + stream_matches)
+
+def logger_has_filter(log: logging.Logger, filter_type: type[logging.Filter]) -> bool:
+    """Check if logger already has a matching filter type."""
+    return any(isinstance(logger_filter, filter_type) for logger_filter in log.filters)
 
 def check_parent_handlers(
     log: logging.Logger,
@@ -650,24 +633,42 @@ def check_parent_handlers(
     logger_parent = log.parent
     this_is_root_logger = logger_parent.name == python_root_logger_name
     while not this_is_root_logger:
-        if _logger_has_handler(logger_parent,handler_type, target_stream):
+        if logger_has_handler(logger_parent,handler_type, target_stream):
             raise LoggerHandlerError(logger_parent.name, handler_type)
         logger_parent = logger_parent.parent
         this_is_root_logger = logger_parent.name == python_root_logger_name
     return
 
+def add_throttle_filter(
+    log: logging.Logger,
+    fallback_handlers: set[HandlerType] | None = None,
+) -> None:
+    """Add the Throttle filter to the logger.
+
+    Args:
+        log (logging.Logger): Logger to add the rich handler to.
+        fallback_handlers (set[HandlerType] | None): Default handler set used when
+            records do not explicitly include handler routing.
+
+    Returns:
+        None
+    """
+    if fallback_handlers is None:
+        fallback_handlers = {HandlerType.Throttle}
+    log.addFilter(ThrottleFilter(fallback_handlers=fallback_handlers))
+    return
 
 def add_rich_handler(
     log: logging.Logger,
     use_parent_handlers: bool,
-    default_case: set[HandlerType] | None = None,
+    fallback_handlers: set[HandlerType] | None = None,
 ) -> None:
     """Add a rich handler to the logger.
 
     Args:
         log (logging.Logger): Logger to add the rich handler to.
         use_parent_handlers (bool): Whether to check parent handlers.
-        default_case (set[HandlerType] | None): Default handler set used when
+        fallback_handlers (set[HandlerType] | None): Default handler set used when
             records do not explicitly include handler routing.
 
     Returns:
@@ -676,8 +677,8 @@ def add_rich_handler(
     Raises:
         LoggerHandlerError: If a parent logger has a rich handler.
     """
-    if default_case is None:
-        default_case = {HandlerType.Rich}
+    if fallback_handlers is None:
+        fallback_handlers = {HandlerType.Rich}
     check_parent_handlers(log, use_parent_handlers, FormattedRichHandler)
     width: int = get_width()
     handler: RichHandler = FormattedRichHandler(width=width)    
@@ -685,7 +686,7 @@ def add_rich_handler(
     handler.addFilter(
         HandleIDFilter(
             handler_id=HandlerType.Rich,
-            default_case=default_case
+            fallback_handlers=fallback_handlers
             )
     )
     log.addHandler(handler)
@@ -695,14 +696,14 @@ def add_ers_kafka_handler(
     log: logging.Logger,
     use_parent_handlers: bool,
     session_name: str,
-    default_case: set[HandlerType] | None = None,
+    fallback_handlers: set[HandlerType] | None = None,
     topic: str = "ers_stream",
     address: str = "monkafka.cern.ch:30092",
 ) -> None:
     # TODO/future: topic and address are new, propagate to all relevant implementation
     """Add an ers protobuf handler to the root logger."""
-    if default_case is None:
-        default_case = {HandlerType.Protobufstream}
+    if fallback_handlers is None:
+        fallback_handlers = {HandlerType.Protobufstream}
     check_parent_handlers(log, use_parent_handlers, ERSKafkaLogHandler)
     handler: ERSKafkaLogHandler = ERSKafkaLogHandler(session=session_name, 
                                                      kafka_address = address, 
@@ -712,7 +713,7 @@ def add_ers_kafka_handler(
     handler.addFilter(
         HandleIDFilter(
             handler_id=HandlerType.Protobufstream,
-            default_case=default_case
+            fallback_handlers=fallback_handlers
             )
     )
     log.addHandler(handler)
@@ -720,14 +721,14 @@ def add_ers_kafka_handler(
 def add_stdout_handler(
     log: logging.Logger,
     use_parent_handlers: bool,
-    default_case: set[HandlerType] | None = None,
+    fallback_handlers: set[HandlerType] | None = None,
 ) -> None:
     """Add a stdout handler to the logger.
 
     Args:
         log (logging.Logger): Logger to add the stdout handler to.
         use_parent_handlers (bool): Whether to check parent handlers.
-        default_case (set[HandlerType] | None): Default handler set used when
+        fallback_handlers (set[HandlerType] | None): Default handler set used when
             records do not explicitly include handler routing.
 
     Returns:
@@ -736,8 +737,8 @@ def add_stdout_handler(
     Raises:
         LoggerHandlerError: If a parent logger has a stdout handler.
     """
-    if default_case is None:
-        default_case = {HandlerType.Stream, HandlerType.Lstdout}
+    if fallback_handlers is None:
+        fallback_handlers = {HandlerType.Stream, HandlerType.Lstdout}
     check_parent_handlers(
         log,
         use_parent_handlers,
@@ -750,7 +751,7 @@ def add_stdout_handler(
     stdout_handler.addFilter(
         HandleIDFilter(
             handler_id=[HandlerType.Stream, HandlerType.Lstdout],
-            default_case=default_case
+            fallback_handlers=fallback_handlers
             )
     )    
     log.addHandler(stdout_handler)
@@ -759,7 +760,7 @@ def add_stdout_handler(
 def add_stderr_handler(
     log: logging.Logger,
     use_parent_handlers: bool,
-    default_case: set[HandlerType] | None = None,
+    fallback_handlers: set[HandlerType] | None = None,
 ) -> None:
     """Add a stderr handler to the logger.
 
@@ -770,7 +771,7 @@ def add_stderr_handler(
     Args:
         log (logging.Logger): Logger to add the stderr handler to.
         use_parent_handlers (bool): Whether to check parent handlers.
-        default_case (set[HandlerType] | None): Default handler set used when
+        fallback_handlers (set[HandlerType] | None): Default handler set used when
             records do not explicitly include handler routing.
 
     Returns:
@@ -779,8 +780,8 @@ def add_stderr_handler(
     Raises:
         LoggerHandlerError: If a parent logger has a stderr handler.
     """
-    if default_case is None:
-        default_case = {HandlerType.Lstderr, HandlerType.Stream}
+    if fallback_handlers is None:
+        fallback_handlers = {HandlerType.Lstderr, HandlerType.Stream}
     check_parent_handlers(
         log,
         use_parent_handlers,
@@ -792,19 +793,18 @@ def add_stderr_handler(
     stderr_handler.addFilter(
         HandleIDFilter(
             handler_id=[HandlerType.Stream, HandlerType.Lstderr],
-            default_case=default_case
+            fallback_handlers=fallback_handlers
             )
     )    
     stderr_handler.setLevel(logging.ERROR)
     log.addHandler(stderr_handler)
     return
 
-
 def add_file_handler(
     log: logging.Logger,
     use_parent_handlers: bool,
     path: str,
-    default_case: set[HandlerType] | None = None,
+    fallback_handlers: set[HandlerType] | None = None,
 ) -> None:
     """Add a file handler to the root logger.
 
@@ -812,7 +812,7 @@ def add_file_handler(
         log (logging.Logger): Logger to add the file handler to.
         use_parent_handlers (bool): Whether to check parent handlers.
         path (str): Path to the log file.
-        default_case (set[HandlerType] | None): Default handler set used when
+        fallback_handlers (set[HandlerType] | None): Default handler set used when
             records do not explicitly include handler routing.
 
     Returns:
@@ -821,25 +821,19 @@ def add_file_handler(
     Raises:
         LoggerHandlerError: If a parent logger has a file handler.
     """
-    if default_case is None:
-        default_case = {HandlerType.File}
+    if fallback_handlers is None:
+        fallback_handlers = {HandlerType.File}
     check_parent_handlers(log, use_parent_handlers, logging.FileHandler)
     file_handler = logging.FileHandler(filename=path)
     file_handler.setFormatter(LoggingFormatter())
     file_handler.addFilter(
         HandleIDFilter(
             handler_id=HandlerType.File,
-            default_case=default_case
+            fallback_handlers=fallback_handlers
             )
     )
     log.addHandler(file_handler)
     return
-
-
-def _logger_has_filter(log: logging.Logger, filter_type: type[logging.Filter]) -> bool:
-    """Check if logger already has a matching filter type."""
-    return any(isinstance(logger_filter, filter_type) for logger_filter in log.filters)
-
 
 def add_handlers_from_types(
     log: logging.Logger,
@@ -847,7 +841,7 @@ def add_handlers_from_types(
     use_parent_handlers: bool,
     file_name: str | None,
     ers_session_name: str | None,
-    default_case: set[HandlerType],
+    fallback_handlers: set[HandlerType],
 ) -> None:
     """Add handlers to a logger based on a set of HandlerType values.
 
@@ -872,12 +866,12 @@ def add_handlers_from_types(
     # Check if current logger has stream handlers, convert to handlertypes
     existing_stream_handlers = {
         HandlerType.Lstdout
-        if _logger_has_handler(
+        if logger_has_handler(
             log, logging.StreamHandler, target_stream=cast(io.IOBase, sys.stdout)
         )
         else None,
         HandlerType.Lstderr
-        if _logger_has_handler(
+        if logger_has_handler(
             log, logging.StreamHandler, target_stream=cast(io.IOBase, sys.stderr)
         )
         else None,
@@ -886,33 +880,33 @@ def add_handlers_from_types(
 
     # Check if current logger has the interested handler
     existing_handlers = {
-        HandlerType.Rich if _logger_has_handler(log, FormattedRichHandler) else None,
+        HandlerType.Rich if logger_has_handler(log, FormattedRichHandler) else None,
         HandlerType.Protobufstream
-        if _logger_has_handler(log, ERSKafkaLogHandler)
+        if logger_has_handler(log, ERSKafkaLogHandler)
         else None,
-        HandlerType.Throttle if _logger_has_filter(log, ThrottleFilter) else None,
-        HandlerType.File if _logger_has_filter(log, logging.FileHandler) else None,
+        HandlerType.Throttle if logger_has_filter(log, ThrottleFilter) else None,
+        HandlerType.File if logger_has_filter(log, logging.FileHandler) else None,
     }
     existing_handlers.discard(None)
     existing_handlers.update(existing_stream_handlers)
 
     handlers_init_map: dict[HandlerType, Callable[[], None]] = {
         HandlerType.Rich: lambda: add_rich_handler(
-            log, use_parent_handlers, default_case
+            log, use_parent_handlers, fallback_handlers
         ),
         HandlerType.Lstdout: lambda: add_stdout_handler(
-            log, use_parent_handlers, default_case
+            log, use_parent_handlers, fallback_handlers
         ),
         HandlerType.Lstderr: lambda: add_stderr_handler(
-            log, use_parent_handlers, default_case
+            log, use_parent_handlers, fallback_handlers
         ),
         HandlerType.File: lambda: add_file_handler(
-            log, use_parent_handlers, file_name, default_case
+            log, use_parent_handlers, file_name, fallback_handlers
         ),
         HandlerType.Protobufstream: lambda: add_ers_kafka_handler(
-            log, use_parent_handlers, ers_session_name, default_case
+            log, use_parent_handlers, ers_session_name, fallback_handlers
         ),
-        HandlerType.Throttle: lambda: add_throttle_filter(log, default_case),
+        HandlerType.Throttle: lambda: add_throttle_filter(log, fallback_handlers),
     }
 
     # Need to clean this bit up
@@ -934,4 +928,3 @@ def add_handlers_from_types(
         if installer is None:
             continue
         installer()
-

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import io
 import logging
 import sys
-from collections.abc import Mapping
 from typing import Any, cast
 
 from erskafka.ERSKafkaLogHandler import ERSKafkaLogHandler
@@ -150,10 +149,10 @@ def logger_or_ancestors_have_handler(
 
 #### Handlers #### 
 
-def _build_rich_handler(extras: Mapping[str, Any]) -> logging.Handler:
+def _build_rich_handler(width: int | None = None, **_: Any) -> logging.Handler:
     """Building the rich handler with any extras."""
-    width = cast(int,  extras.get("width", get_width()))
-    return FormattedRichHandler(width=width)
+    real_width = width if width is not None else get_width()
+    return FormattedRichHandler(width=real_width)
 
 RICH_HANDLER_SPEC = HandlerSpec(
     representative_type = HandlerType.Rich,
@@ -162,8 +161,7 @@ RICH_HANDLER_SPEC = HandlerSpec(
     filter_handler_ids = (HandlerType.Rich,), # For HandleIDFilter
 )
 
-def _build_stdout_handler(extras: Mapping[str, Any]) -> logging.Handler:
-    del extras #unused
+def _build_stdout_handler(**_: Any) -> logging.Handler:
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(LoggingFormatter())
     return handler
@@ -176,8 +174,7 @@ STDOUT_HANDLER_SPEC = HandlerSpec(
     filter_handler_ids = (HandlerType.Stream, HandlerType.Lstdout),
 )
 
-def _build_stderr_handler(extras: Mapping[str, Any]) -> logging.Handler:
-    del extras #unused
+def _build_stderr_handler(**_: Any) -> logging.Handler:
     handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(LoggingFormatter())
     handler.setLevel(logging.ERROR)
@@ -191,10 +188,9 @@ STDERR_HANDLER_SPEC = HandlerSpec(
     filter_handler_ids = (HandlerType.Stream, HandlerType.Lstderr),
 )
 
-def _build_file_handler(extras: Mapping[str, Any]) -> logging.Handler:
-    path = cast(str | None, extras.get("path"))
+def _build_file_handler(path: str | None = None, **_: Any) -> logging.Handler:
     if not path:
-        err_msg = "path is requiired for file handler"
+        err_msg = "path is required for file handler"
         raise ValueError(err_msg)
     handler = logging.FileHandler(filename=path)
     handler.setFormatter(LoggingFormatter())
@@ -208,21 +204,18 @@ FILE_HANDLER_SPEC = HandlerSpec(
     filter_handler_ids=(HandlerType.File,)
 )
 
-def _build_erskafka_handler(extras: Mapping[str, Any]) -> logging.Handler: 
-    session_name = cast( str | None, extras.get("session_name"))
+def _build_erskafka_handler(
+        session_name : str,
+        topic : str = "ers_stream",
+        address : str = "monkafka.cern.ch:30092",
+        ers_app_name : str | None = None,
+        **_) -> logging.Handler: 
 
-    if not session_name:
-        err_msg = "'session_name' is required for erskafka handler"
-        raise ValueError(err_msg)
-
-    topic = cast(str, extras.get("topic", "ers_stream"))
-    address = cast(str, extras.get("address", "monkafka.cern.ch:30092"))
-    app_name = cast(str, extras.get("app_name", None))
     return ERSKafkaLogHandler(
         session = session_name,
         kafka_address=address,
         kafka_topic = topic,
-        app_name=app_name
+        app_name=ers_app_name
     )
     
 ERSKAFKA_HANDLER_SPEC = HandlerSpec(
@@ -253,7 +246,7 @@ def add_handler(
     handler_type: HandlerType | str, 
     use_parent_handlers:bool, 
     fallback_handler: set[HandlerType] | None = None,
-    extras: Mapping[str, Any] | None = None,
+    **extras: Any
 ):    
     ht = HandlerType.from_string(handler_type) if isinstance(handler_type, str) else handler_type
     specs = get_handler_specs(ht) 
@@ -265,7 +258,6 @@ def add_handler(
             spec.handler_type,
             target_stream=spec.target_stream,
         ):
-            # raise ValueError('HEY THEY ALREADY EXIST')
             continue
             
 
@@ -276,7 +268,7 @@ def add_handler(
             target_stream = spec.target_stream
         )
 
-        handler = spec.factory(extras or {})
+        handler = spec.factory(**extras)
         effective_default_case = fallback_handler if fallback_handler is not None else spec.filter_handler_ids
 
         handler_ids: HandlerType | list[HandlerType]
@@ -291,7 +283,6 @@ def add_handler(
                 fallback_handlers=effective_default_case
             )
         )
-
         log.addHandler(handler)
 
 
@@ -301,7 +292,7 @@ def add_handlers_from_types(
     handler_types: set[HandlerType],
     use_parent_handlers: bool,
     fallback_handlers: set[HandlerType],
-    extras: Mapping[str, Any] | None = None,
+    **extras: Any,
 ) -> None:
     """Add handlers and filters from a set of HandlerType values.
 
@@ -322,10 +313,10 @@ def add_handlers_from_types(
                 handler_type,
                 use_parent_handlers,
                 fallback_handlers,
-                extras,
+                **extras,
             )
             continue
 
         filter_spec = get_filter_spec(handler_type)
         if filter_spec and not logger_has_filter(log, filter_spec.filter_type):
-            add_filter(log, handler_type, fallback_handlers, extras)
+            add_filter(log, handler_type, fallback_handlers, **extras)

--- a/src/daqpytools/logging/handlers.py
+++ b/src/daqpytools/logging/handlers.py
@@ -234,10 +234,31 @@ FILE_HANDLER_SPEC = HandlerSpec(
 
 
 
+def _build_erskafka_handler(extras: Mapping[str, Any]) -> logging.Handler: 
+    session_name = cast( str | None, extras.get("session_name"))
+
+    if not session_name:
+        err_msg = "'session_name' is required for erskafka handler"
+        raise ValueError(err_msg)
+
+    topic = cast(str, extras.get("topic", "ers_stream"))
+    address = cast(str, extras.get("address", "monkafka.cern.ch:30092"))
+    app_name = cast(str, extras.get("app_name", None))
+    return ERSKafkaLogHandler(
+        session = session_name,
+        kafka_address=address,
+        kafka_topic = topic,
+        app_name=app_name
+    )
+    
 
 
-
-
+ERSKAFKA_HANDLER_SPEC = HandlerSpec(
+    representative_type=HandlerType.Protobufstream,
+    handler_type = ERSKafkaLogHandler,
+    factory = _build_erskafka_handler,
+    filter_handler_ids=[HandlerType.Protobufstream],
+)
 
 
 
@@ -247,7 +268,8 @@ HANDLER_SPEC_REGISTRY : dict[HandlerType, tuple[HandlerSpec, ...]] = {
     HandlerType.Lstdout: (STDOUT_HANDLER_SPEC,),
     HandlerType.Lstderr: (STDERR_HANDLER_SPEC,),
     HandlerType.Stream: (STDOUT_HANDLER_SPEC,STDERR_HANDLER_SPEC),
-    HandlerType.File: (FILE_HANDLER_SPEC,)
+    HandlerType.File: (FILE_HANDLER_SPEC,),
+    HandlerType.Protobufstream: (ERSKAFKA_HANDLER_SPEC,)
 }
 
 def get_handler_specs(handler_type: HandlerType):
@@ -349,6 +371,28 @@ def add_file_handler(
             "path" : path
         }
     )
+
+def add_ers_kafka_handler(
+    log: logging.Logger,
+    use_parent_handlers: bool,
+    session_name: str,
+    fallback_handlers: set[HandlerType] | None = None,
+    app_name : str|None =None,
+    topic: str = "ers_stream",
+    address: str = "monkafka.cern.ch:30092",
+) -> None:
+    add_handler(
+        log,
+        HandlerType.Protobufstream,
+        use_parent_handlers,
+        fallback_handlers,
+        extras={
+            "session_name": session_name,
+            "topic": topic,
+            "address": address,
+            "app_name": app_name,
+        },
+    )
     
 
 from daqpytools.logging.filters import add_throttle_filter
@@ -361,33 +405,33 @@ from daqpytools.logging.filters import add_throttle_filter
 
 
 
-def add_ers_kafka_handler(
-    log: logging.Logger,
-    use_parent_handlers: bool,
-    session_name: str,
-    fallback_handlers: set[HandlerType] | None = None,
-    app_name : str|None =None,
-    topic: str = "ers_stream",
-    address: str = "monkafka.cern.ch:30092",
-) -> None:
-    # TODO/future: topic and address are new, propagate to all relevant implementation
-    """Add an ers protobuf handler to the root logger."""
-    if fallback_handlers is None:
-        fallback_handlers = {HandlerType.Protobufstream}
-    check_parent_handlers(log, use_parent_handlers, ERSKafkaLogHandler)
-    handler: ERSKafkaLogHandler = ERSKafkaLogHandler(session=session_name, 
-                                                     kafka_address = address, 
-                                                     kafka_topic = topic,
-                                                     app_name = app_name,
-                                                     )
+# def add_ers_kafka_handler(
+#     log: logging.Logger,
+#     use_parent_handlers: bool,
+#     session_name: str,
+#     fallback_handlers: set[HandlerType] | None = None,
+#     app_name : str|None =None,
+#     topic: str = "ers_stream",
+#     address: str = "monkafka.cern.ch:30092",
+# ) -> None:
+#     # TODO/future: topic and address are new, propagate to all relevant implementation
+#     """Add an ers protobuf handler to the root logger."""
+#     if fallback_handlers is None:
+#         fallback_handlers = {HandlerType.Protobufstream}
+#     check_parent_handlers(log, use_parent_handlers, ERSKafkaLogHandler)
+#     handler: ERSKafkaLogHandler = ERSKafkaLogHandler(session=session_name, 
+#                                                      kafka_address = address, 
+#                                                      kafka_topic = topic,
+#                                                      app_name = app_name,
+#                                                      )
 
-    handler.addFilter(
-        HandleIDFilter(
-            handler_id=HandlerType.Protobufstream,
-            fallback_handlers=fallback_handlers
-            )
-    )
-    log.addHandler(handler)
+#     handler.addFilter(
+#         HandleIDFilter(
+#             handler_id=HandlerType.Protobufstream,
+#             fallback_handlers=fallback_handlers
+#             )
+#     )
+#     log.addHandler(handler)
 
 # def add_file_handler(
 #     log: logging.Logger,

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -71,7 +71,7 @@ def get_daq_logger(
     rich_handler: bool = False,
     file_handler_path: str | None = None,
     stream_handlers: bool = False,
-    ers_kafka_handler: bool = False,
+    ers_kafka_handler: str | None = None,
     throttle: bool = False
 ) -> logging.Logger:
     """C'tor for the default logging instances.
@@ -84,7 +84,7 @@ def get_daq_logger(
         file_handler_path (str | None): Path to the file handler log file. If None, no
             file handler is added.
         stream_handlers (bool): Whether to add both stdout and stderr stream handlers.
-        ers_kafka_handler (bool): Whether to add an ERS protobuf handler.
+        ers_kafka_handler (str): Whether to add an ERS protobuf handler. str is session name
         throttle (bool): Whether to add the throttle filter or not. Note, does not mean 
             outputs are filtered by default! See ThrottleFilter for details.
 
@@ -150,7 +150,7 @@ def get_daq_logger(
         add_stdout_handler(logger, use_parent_handlers)
         add_stderr_handler(logger, use_parent_handlers)
     if ers_kafka_handler: 
-        add_ers_kafka_handler(logger, use_parent_handlers, "session_tester")
+        add_ers_kafka_handler(logger, use_parent_handlers, ers_kafka_handler)
 
     if throttle:
         # Note: Default parameters used. No functionality on customisability yet

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -187,18 +187,42 @@ def setup_daq_ers_logger(
     Returns:
         None
     """
+    oks_conf = LogHandlerConf._get_oks_conf()
+
+    protobuf_configs = {
+        handler_conf.protobufconf
+        for handler_conf in oks_conf.values()
+        if handler_conf.protobufconf is not None
+    }
+
+    if len(protobuf_configs) > 1:
+        err_msg = (
+            "Multiple protobufstream(url:port) configurations are not supported "
+            "in Python ERS logger setup"
+        )
+        raise ValueError(err_msg)
+
+    protobuf_config = next(iter(protobuf_configs), None)
+    kafka_address = protobuf_config.get_string() if protobuf_config else None
+
     all_handlers = {
         handler
-        for handler_conf in LogHandlerConf._get_oks_conf().values()
+        for handler_conf in oks_conf.values()
         for handler in handler_conf.handlers
+        if handler is not None
     }
+
+    add_ers_kwargs = {
+        "session_name": ers_kafka_session,
+        "ers_app_name": ers_app_name,
+    }
+    if kafka_address is not None:
+        add_ers_kwargs["address"] = kafka_address
 
     add_handlers_from_types(
         logger,
         all_handlers,
         use_parent_handlers=True,
         fallback_handlers={HandlerType.Unknown},
-        session_name=ers_kafka_session,
-        app_name = ers_app_name
+        **add_ers_kwargs,
     )
-

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -8,10 +8,11 @@ from rich.traceback import install as rich_traceback_install
 
 from daqpytools.logging.exceptions import LoggerSetupError
 from daqpytools.logging.handlers import (
-    HandlerType,
-    LogHandlerConf,
     add_handlers_from_types,
 )
+
+from daqpytools.logging.handlerconf import LogHandlerConf, HandlerType
+
 from daqpytools.logging.levels import logging_log_level_to_int
 from daqpytools.logging.utils import get_width
 
@@ -157,9 +158,11 @@ def get_daq_logger(
         fallback_handlers,
         use_parent_handlers,
         fallback_handlers,
-        file_handler_path,
-        ers_kafka_session,
-        ers_app_name,
+        {
+            "path": file_handler_path,
+            "session_name": ers_kafka_session,
+            "app_name": ers_app_name,
+        },
     )
 
     # Set log level for all handlers if requested
@@ -199,9 +202,9 @@ def setup_daq_ers_logger(
         all_handlers,
         use_parent_handlers=True,
         fallback_handlers={HandlerType.Unknown},
-        file_name=None,
-        ers_kafka_session=ers_kafka_session,
-        app_name = ers_app_name
-        
+        extras={
+            "session_name": ers_kafka_session,
+            "app_name": ers_app_name,
+        },
     )
 

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -8,15 +8,9 @@ from rich.traceback import install as rich_traceback_install
 
 from daqpytools.logging.exceptions import LoggerSetupError
 from daqpytools.logging.handlers import (
+    HandlerType,
     LogHandlerConf,
     add_handlers_from_types,
-    add_throttle_filter,
-    add_ers_kafka_handler,
-    add_file_handler,
-    add_rich_handler,
-    add_stderr_handler,
-    add_stdout_handler,
-    HandlerType
 )
 from daqpytools.logging.levels import logging_log_level_to_int
 from daqpytools.logging.utils import get_width
@@ -76,8 +70,6 @@ def get_daq_logger(
     stream_handlers: bool = False,
     ers_kafka_handler: str | None = None,
     throttle: bool = False,
-
-    setup_ers_handlers: bool = False,
 ) -> logging.Logger:
     """C'tor for the default logging instances.
 
@@ -89,8 +81,9 @@ def get_daq_logger(
         file_handler_path (str | None): Path to the file handler log file. If None, no
             file handler is added.
         stream_handlers (bool): Whether to add both stdout and stderr stream handlers.
-        ers_kafka_handler (str): Whether to add an ERS protobuf handler. str is session name
-        throttle (bool): Whether to add the throttle filter or not. Note, does not mean 
+        ers_kafka_handler (str | None): ERS session name used to add an ERS
+            protobuf handler. If None, no ERS protobuf handler is added.
+        throttle (bool): Whether to add the throttle filter or not. Note, does not mean
             outputs are filtered by default! See ThrottleFilter for details.
 
     Returns:
@@ -146,42 +139,26 @@ def get_daq_logger(
         logger.setLevel(log_level)
     logger.propagate = use_parent_handlers
 
-    #! Okay so before this bit, you capture all the handlers that you want to have
-    # That would now be the default base handlers
-    # You apss this in each of the requested handlers here..
-
-
-    default_case = {HandlerType.Rich}
-
-    # Add requested handlers
-    # if rich_handler:
-    #     add_rich_handler(logger, use_parent_handlers)
-    # if file_handler_path:
-    #     add_file_handler(logger, use_parent_handlers, file_handler_path)
-    # if stream_handlers:
-    #     add_stdout_handler(logger, use_parent_handlers)
-    #     add_stderr_handler(logger, use_parent_handlers)
-    # if ers_kafka_handler:
-    #     add_ers_kafka_handler(logger, use_parent_handlers, ers_kafka_handler)
-
-    # if throttle:
-    #     # Note: Default parameters used. No functionality on customisability yet
-    #     add_throttle_filter(logger)
-
-
+    default_case: set[HandlerType] = set()
     if rich_handler:
-        add_rich_handler(logger, use_parent_handlers, default_case)
+        default_case.add(HandlerType.Rich)
     if file_handler_path:
-        add_file_handler(logger, use_parent_handlers, file_handler_path, default_case)
+        default_case.add(HandlerType.File)
     if stream_handlers:
-        add_stdout_handler(logger, use_parent_handlers, default_case)
-        add_stderr_handler(logger, use_parent_handlers, default_case)
+        default_case.add(HandlerType.Stream)
     if ers_kafka_handler:
-        add_ers_kafka_handler(logger, use_parent_handlers, ers_kafka_handler, default_case)
-
+        default_case.add(HandlerType.Protobufstream)
     if throttle:
-        # Note: Default parameters used. No functionality on customisability yet
-        add_throttle_filter(logger, default_case)
+        default_case.add(HandlerType.Throttle)
+
+    add_handlers_from_types(
+        logger,
+        default_case,
+        use_parent_handlers,
+        file_handler_path,
+        ers_kafka_handler,
+        default_case,
+    )
 
 
 
@@ -197,19 +174,31 @@ def get_daq_logger(
     return logger
 
 
-#! This will mean now that you need some function here that will allow you to go through all the handlers and all the filters and update that stupid self.default_case
+def setup_daq_ers_logger(
+    logger: logging.Logger,
+    ers_session_name: str,
+) -> None:
+    """Configure logger handlers from ERS environment-derived configuration.
 
-def setup_daq_ers_logger(logger, ers_session_name):
+    Args:
+        logger (logging.Logger): Logger to configure.
+        ers_session_name (str): ERS session name used for protobufstream handler.
 
-    # need to grab the list of relevant handlers that exist in ERS
-    #! This is very dependent on ERS env variables existing!!! 
-    
-    all_handlers = {handler for handler_conf in LogHandlerConf._get_oks_conf().values() for handler in handler_conf.handlers}
-    
-    print(f"{all_handlers=}")
+    Returns:
+        None
+    """
+    all_handlers = {
+        handler
+        for handler_conf in LogHandlerConf._get_oks_conf().values()
+        for handler in handler_conf.handlers
+    }
 
-    add_handlers_from_types(logger, all_handlers, ers_session_name)
-
-
-    # now what.. Well we have a list of handlers to add now huh..
+    add_handlers_from_types(
+        logger,
+        all_handlers,
+        use_parent_handlers=True,
+        file_name=None,
+        ers_session_name=ers_session_name,
+        default_case={HandlerType.Unknown},
+    )
 

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -139,25 +139,25 @@ def get_daq_logger(
         logger.setLevel(log_level)
     logger.propagate = use_parent_handlers
 
-    default_case: set[HandlerType] = set()
+    fallback_handlers: set[HandlerType] = set()
     if rich_handler:
-        default_case.add(HandlerType.Rich)
+        fallback_handlers.add(HandlerType.Rich)
     if file_handler_path:
-        default_case.add(HandlerType.File)
+        fallback_handlers.add(HandlerType.File)
     if stream_handlers:
-        default_case.add(HandlerType.Stream)
+        fallback_handlers.add(HandlerType.Stream)
     if ers_kafka_handler:
-        default_case.add(HandlerType.Protobufstream)
+        fallback_handlers.add(HandlerType.Protobufstream)
     if throttle:
-        default_case.add(HandlerType.Throttle)
+        fallback_handlers.add(HandlerType.Throttle)
 
     add_handlers_from_types(
         logger,
-        default_case,
+        fallback_handlers,
         use_parent_handlers,
         file_handler_path,
         ers_kafka_handler,
-        default_case,
+        fallback_handlers,
     )
 
 
@@ -199,6 +199,6 @@ def setup_daq_ers_logger(
         use_parent_handlers=True,
         file_name=None,
         ers_session_name=ers_session_name,
-        default_case={HandlerType.Unknown},
+        fallback_handlers={HandlerType.Unknown},
     )
 

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -145,6 +145,10 @@ def get_daq_logger(
         logger.setLevel(log_level)
     logger.propagate = use_parent_handlers
 
+    #! Okay so before this bit, you capture all the handlers that you want to have
+    # That would now be the default base handlers
+    # You apss this in each of the requested handlers here..
+
     # Add requested handlers
     if rich_handler:
         add_rich_handler(logger, use_parent_handlers)
@@ -162,18 +166,6 @@ def get_daq_logger(
 
 
 
-    if setup_ers_handlers:
-
-        # need to grab the list of relevant handlers that exist in ERS
-        #! This is very dependent on ERS env variables existing!!! 
-        lhc_conf = LogHandlerConf._get_oks_conf()
-        all_handlers = {handler for handler_conf in lhc_conf.values() for handler in handler_conf.handlers}
-        
-        print(all_handlers)
-
-        add_handlers_from_types(logger, all_handlers, ers_kafka_handler)
-
-        # now what.. Well we have a list of handlers to add now huh..
 
 
 
@@ -191,3 +183,21 @@ def get_daq_logger(
             handler.setLevel(log_level)
 
     return logger
+
+
+#! This will mean now that you need some function here that will allow you to go through all the handlers and all the filters and update that stupid self.default_case
+
+def setup_daq_ers_logger(logger, ers_session_name):
+
+    # need to grab the list of relevant handlers that exist in ERS
+    #! This is very dependent on ERS env variables existing!!! 
+    
+    all_handlers = {handler for handler_conf in LogHandlerConf._get_oks_conf().values() for handler in handler_conf.handlers}
+    
+    print(all_handlers)
+
+    add_handlers_from_types(logger, all_handlers, ers_session_name)
+
+
+    # now what.. Well we have a list of handlers to add now huh..
+

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -68,7 +68,8 @@ def get_daq_logger(
     rich_handler: bool = False,
     file_handler_path: str | None = None,
     stream_handlers: bool = False,
-    ers_kafka_handler: str | None = None,
+    ers_kafka_session: str | None = None,
+    ers_app_name: str | None = None,
     throttle: bool = False,
 ) -> logging.Logger:
     """C'tor for the default logging instances.
@@ -81,7 +82,7 @@ def get_daq_logger(
         file_handler_path (str | None): Path to the file handler log file. If None, no
             file handler is added.
         stream_handlers (bool): Whether to add both stdout and stderr stream handlers.
-        ers_kafka_handler (str | None): ERS session name used to add an ERS
+        ers_kafka_session (str | None): ERS session name used to add an ERS
             protobuf handler. If None, no ERS protobuf handler is added.
         throttle (bool): Whether to add the throttle filter or not. Note, does not mean
             outputs are filtered by default! See ThrottleFilter for details.
@@ -146,7 +147,7 @@ def get_daq_logger(
         fallback_handlers.add(HandlerType.File)
     if stream_handlers:
         fallback_handlers.add(HandlerType.Stream)
-    if ers_kafka_handler:
+    if ers_kafka_session:
         fallback_handlers.add(HandlerType.Protobufstream)
     if throttle:
         fallback_handlers.add(HandlerType.Throttle)
@@ -155,12 +156,11 @@ def get_daq_logger(
         logger,
         fallback_handlers,
         use_parent_handlers,
-        file_handler_path,
-        ers_kafka_handler,
         fallback_handlers,
+        file_handler_path,
+        ers_kafka_session,
+        ers_app_name,
     )
-
-
 
     # Set log level for all handlers if requested
     if log_level is not logging.NOTSET:
@@ -176,13 +176,14 @@ def get_daq_logger(
 
 def setup_daq_ers_logger(
     logger: logging.Logger,
-    ers_session_name: str,
+    ers_kafka_session: str,
+    ers_app_name : str | None = None
 ) -> None:
     """Configure logger handlers from ERS environment-derived configuration.
 
     Args:
         logger (logging.Logger): Logger to configure.
-        ers_session_name (str): ERS session name used for protobufstream handler.
+        ers_kafka_session (str): ERS session name used for protobufstream handler.
 
     Returns:
         None
@@ -197,8 +198,10 @@ def setup_daq_ers_logger(
         logger,
         all_handlers,
         use_parent_handlers=True,
-        file_name=None,
-        ers_session_name=ers_session_name,
         fallback_handlers={HandlerType.Unknown},
+        file_name=None,
+        ers_kafka_session=ers_kafka_session,
+        app_name = ers_app_name
+        
     )
 

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -149,7 +149,7 @@ def get_daq_logger(
     if stream_handlers:
         add_stdout_handler(logger, use_parent_handlers)
         add_stderr_handler(logger, use_parent_handlers)
-    if ers_kafka_handler: 
+    if ers_kafka_handler:
         add_ers_kafka_handler(logger, use_parent_handlers, ers_kafka_handler)
 
     if throttle:

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -8,7 +8,9 @@ from rich.traceback import install as rich_traceback_install
 
 from daqpytools.logging.exceptions import LoggerSetupError
 from daqpytools.logging.handlers import (
-    ThrottleFilter,
+    LogHandlerConf,
+    add_handlers_from_types,
+    add_throttle_filter,
     add_ers_kafka_handler,
     add_file_handler,
     add_rich_handler,
@@ -72,7 +74,9 @@ def get_daq_logger(
     file_handler_path: str | None = None,
     stream_handlers: bool = False,
     ers_kafka_handler: str | None = None,
-    throttle: bool = False
+    throttle: bool = False,
+
+    setup_ers_handlers: bool = False,
 ) -> logging.Logger:
     """C'tor for the default logging instances.
 
@@ -154,7 +158,28 @@ def get_daq_logger(
 
     if throttle:
         # Note: Default parameters used. No functionality on customisability yet
-        logger.addFilter(ThrottleFilter())
+        add_throttle_filter(logger)
+
+
+
+    if setup_ers_handlers:
+
+        # need to grab the list of relevant handlers that exist in ERS
+        #! This is very dependent on ERS env variables existing!!! 
+        lhc_conf = LogHandlerConf._get_oks_conf()
+        all_handlers = {handler for handler_conf in lhc_conf.values() for handler in handler_conf.handlers}
+        
+        print(all_handlers)
+
+        add_handlers_from_types(logger, all_handlers, ers_kafka_handler)
+
+        # now what.. Well we have a list of handlers to add now huh..
+
+
+
+
+
+
 
     # Set log level for all handlers if requested
     if log_level is not logging.NOTSET:

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -7,12 +7,10 @@ import sh
 from rich.traceback import install as rich_traceback_install
 
 from daqpytools.logging.exceptions import LoggerSetupError
+from daqpytools.logging.handlerconf import HandlerType, LogHandlerConf
 from daqpytools.logging.handlers import (
     add_handlers_from_types,
 )
-
-from daqpytools.logging.handlerconf import LogHandlerConf, HandlerType
-
 from daqpytools.logging.levels import logging_log_level_to_int
 from daqpytools.logging.utils import get_width
 
@@ -70,8 +68,8 @@ def get_daq_logger(
     file_handler_path: str | None = None,
     stream_handlers: bool = False,
     ers_kafka_session: str | None = None,
-    ers_app_name: str | None = None,
     throttle: bool = False,
+    **extras
 ) -> logging.Logger:
     """C'tor for the default logging instances.
 
@@ -158,11 +156,9 @@ def get_daq_logger(
         fallback_handlers,
         use_parent_handlers,
         fallback_handlers,
-        {
-            "path": file_handler_path,
-            "session_name": ers_kafka_session,
-            "app_name": ers_app_name,
-        },
+        path=file_handler_path,
+        session_name=ers_kafka_session,
+        **extras
     )
 
     # Set log level for all handlers if requested
@@ -202,9 +198,7 @@ def setup_daq_ers_logger(
         all_handlers,
         use_parent_handlers=True,
         fallback_handlers={HandlerType.Unknown},
-        extras={
-            "session_name": ers_kafka_session,
-            "app_name": ers_app_name,
-        },
+        session_name=ers_kafka_session,
+        app_name = ers_app_name
     )
 

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -69,7 +69,7 @@ def get_daq_logger(
     stream_handlers: bool = False,
     ers_kafka_session: str | None = None,
     throttle: bool = False,
-    **extras
+    **extras: object
 ) -> logging.Logger:
     """C'tor for the default logging instances.
 
@@ -85,6 +85,7 @@ def get_daq_logger(
             protobuf handler. If None, no ERS protobuf handler is added.
         throttle (bool): Whether to add the throttle filter or not. Note, does not mean
             outputs are filtered by default! See ThrottleFilter for details.
+        **extras (object): Extra keyword arguments forwarded to handler builders.
 
     Returns:
         logging.Logger: Configured logger instance.
@@ -183,6 +184,7 @@ def setup_daq_ers_logger(
     Args:
         logger (logging.Logger): Logger to configure.
         ers_kafka_session (str): ERS session name used for protobufstream handler.
+        ers_app_name (str | None): Optional ERS application name for kafka handler.
 
     Returns:
         None

--- a/src/daqpytools/logging/logger.py
+++ b/src/daqpytools/logging/logger.py
@@ -16,6 +16,7 @@ from daqpytools.logging.handlers import (
     add_rich_handler,
     add_stderr_handler,
     add_stdout_handler,
+    HandlerType
 )
 from daqpytools.logging.levels import logging_log_level_to_int
 from daqpytools.logging.utils import get_width
@@ -149,27 +150,38 @@ def get_daq_logger(
     # That would now be the default base handlers
     # You apss this in each of the requested handlers here..
 
+
+    default_case = {HandlerType.Rich}
+
     # Add requested handlers
+    # if rich_handler:
+    #     add_rich_handler(logger, use_parent_handlers)
+    # if file_handler_path:
+    #     add_file_handler(logger, use_parent_handlers, file_handler_path)
+    # if stream_handlers:
+    #     add_stdout_handler(logger, use_parent_handlers)
+    #     add_stderr_handler(logger, use_parent_handlers)
+    # if ers_kafka_handler:
+    #     add_ers_kafka_handler(logger, use_parent_handlers, ers_kafka_handler)
+
+    # if throttle:
+    #     # Note: Default parameters used. No functionality on customisability yet
+    #     add_throttle_filter(logger)
+
+
     if rich_handler:
-        add_rich_handler(logger, use_parent_handlers)
+        add_rich_handler(logger, use_parent_handlers, default_case)
     if file_handler_path:
-        add_file_handler(logger, use_parent_handlers, file_handler_path)
+        add_file_handler(logger, use_parent_handlers, file_handler_path, default_case)
     if stream_handlers:
-        add_stdout_handler(logger, use_parent_handlers)
-        add_stderr_handler(logger, use_parent_handlers)
+        add_stdout_handler(logger, use_parent_handlers, default_case)
+        add_stderr_handler(logger, use_parent_handlers, default_case)
     if ers_kafka_handler:
-        add_ers_kafka_handler(logger, use_parent_handlers, ers_kafka_handler)
+        add_ers_kafka_handler(logger, use_parent_handlers, ers_kafka_handler, default_case)
 
     if throttle:
         # Note: Default parameters used. No functionality on customisability yet
-        add_throttle_filter(logger)
-
-
-
-
-
-
-
+        add_throttle_filter(logger, default_case)
 
 
 
@@ -194,7 +206,7 @@ def setup_daq_ers_logger(logger, ers_session_name):
     
     all_handlers = {handler for handler_conf in LogHandlerConf._get_oks_conf().values() for handler in handler_conf.handlers}
     
-    print(all_handlers)
+    print(f"{all_handlers=}")
 
     add_handlers_from_types(logger, all_handlers, ers_session_name)
 

--- a/src/daqpytools/logging/rich_handler.py
+++ b/src/daqpytools/logging/rich_handler.py
@@ -1,29 +1,20 @@
 from __future__ import annotations
 
 import logging
-import os
-import re
-from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
-from typing import ClassVar
 
 from rich.console import Console, ConsoleRenderable
 from rich.logging import RichHandler
 from rich.text import Text
 
-from daqpytools.logging.exceptions import (
-    ERSEnvError,
-    ProtobufFormatError,
-)
 from daqpytools.logging.formatter import (
     CONSOLE_THEME,
     DATE_TIME_FORMAT,
     LOG_RECORD_PADDING,
     TIME_ZONE,
 )
-from daqpytools.logging.levels import level_to_ers_var, logging_log_level_to_str
-from daqpytools.logging.utils import get_width
+from daqpytools.logging.levels import logging_log_level_to_str
+
 
 class FormattedRichHandler(RichHandler):
     """RichHandler that formats log messages with time, aligned columns, and styles."""

--- a/src/daqpytools/logging/rich_handler.py
+++ b/src/daqpytools/logging/rich_handler.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import ClassVar
+
+from rich.console import Console, ConsoleRenderable
+from rich.logging import RichHandler
+from rich.text import Text
+
+from daqpytools.logging.exceptions import (
+    ERSEnvError,
+    ProtobufFormatError,
+)
+from daqpytools.logging.formatter import (
+    CONSOLE_THEME,
+    DATE_TIME_FORMAT,
+    LOG_RECORD_PADDING,
+    TIME_ZONE,
+)
+from daqpytools.logging.levels import level_to_ers_var, logging_log_level_to_str
+from daqpytools.logging.utils import get_width
+
+class FormattedRichHandler(RichHandler):
+    """RichHandler that formats log messages with time, aligned columns, and styles."""
+
+    def __init__(self, width: int = 100) -> None:
+        """Initialize with custom console and style settings."""
+        console: Console = Console(
+            force_terminal=True, width=width, theme=CONSOLE_THEME
+        )
+        super().__init__(
+            console=console,
+            omit_repeated_times=False,
+            markup=True,
+            rich_tracebacks=True,
+            show_path=False,
+            show_time=False,  # We format time ourselves
+        )
+
+    def render(
+        self,
+        *,
+        record: logging.LogRecord,
+        traceback: object,
+        message_renderable: ConsoleRenderable,
+    ) -> Text:
+        """Render the log record into a rich Text object with custom formatting.
+
+        Args:
+            record (logging.LogRecord): The log record to render.
+            traceback (object): The traceback object (not used here).
+            message_renderable (ConsoleRenderable): The log message renderable.
+
+        Returns:
+            Text: The formatted log record as a rich Text object.
+
+        Raises:
+            None
+        """
+        dt: datetime = datetime.fromtimestamp(record.created, tz=TIME_ZONE)
+        padding: int = LOG_RECORD_PADDING.get("time", 25)
+        time_str: str = dt.strftime(DATE_TIME_FORMAT).ljust(padding)[:padding]
+        time_text: Text = Text(time_str, style="logging.time")
+
+        padding = LOG_RECORD_PADDING.get("level", 10)
+        level_text: Text = Text(
+            record.levelname.ljust(padding)[:padding],
+            style=self._get_level_style(record.levelno),
+        )
+
+        file_and_no: str = f"{record.filename}:{record.lineno}"
+        padding = LOG_RECORD_PADDING.get("file_and_line", 40)
+        file_and_no_text: Text = Text(
+            file_and_no.ljust(padding)[:padding], style="logging.location"
+        )
+
+        padding = LOG_RECORD_PADDING.get("logger_name", 45)
+        logger_name_text: Text = Text(
+            f"{record.name}".ljust(padding)[:padding], style="logging.logger_name"
+        )
+
+        # Convert message_renderable to Text for type consistency
+        message_text: Text
+        if isinstance(message_renderable, Text):
+            message_text = message_renderable
+        else:
+            message_text = Text.from_markup(str(message_renderable))
+
+        components: list[Text] = [
+            time_text,
+            level_text,
+            file_and_no_text,
+            logger_name_text,
+            message_text,
+        ]
+
+        return Text(" ").join(components)
+
+    def _get_level_style(self, level_no: int) -> str:
+        """Get the style string for the given log level number from the theme defined in
+        CONSOLE_THEME.
+
+        Args:
+            level_no (int): The log level number.
+
+        Returns:
+            str: The style string for the log level.
+        """
+        return str(
+            CONSOLE_THEME.styles.get(
+                f"logging.level.{logging_log_level_to_str(level_no).lower()}", ""
+            )
+        )
+

--- a/src/daqpytools/logging/routing.py
+++ b/src/daqpytools/logging/routing.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any
 
-from daqpytools.logging.handlerdataclasses import StreamType
+from daqpytools.logging.handlerconf import StreamType
 from daqpytools.logging.levels import level_to_ers_var
 
 """

--- a/src/daqpytools/logging/routing.py
+++ b/src/daqpytools/logging/routing.py
@@ -1,0 +1,88 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+from daqpytools.logging.handlerdataclasses import StreamType
+from daqpytools.logging.levels import level_to_ers_var
+
+"""
+So this file basically allows us to define the set of handlers that the logger should send to 
+"""
+
+
+class AllowedHandlersStrategy(ABC):
+    """Strategy for resolving allowed handler types for a log record"""
+
+    @abstractmethod
+    def resolve(
+        self,
+        record: logging.LogRecord,
+        fallback_handlers : set[Any]
+    ) -> set[Any] | None:
+        """Resolve allowd handlers for a given record."""
+
+    def safe_return_set(self, raw_set : set[Any]) -> set[Any] | None:
+        return {obj for obj in raw_set if obj is not None}
+
+
+
+class DefaultAllowedHandlerStrategy(AllowedHandlersStrategy):
+    """Resolve allowed handlers from record.handlers, or a fallback case"""
+
+    def resolve(
+        self,
+        record: logging.LogRecord,
+        fallback_handlers : set[Any]
+    ) -> set[Any] | None:
+        allowed = getattr(record, "handlers", fallback_handlers)
+        if allowed is None:
+            return None
+        return self.safe_return_set(allowed)
+
+class ERSAllowedHandlersStrategy(AllowedHandlersStrategy):
+    """Resolve allowed handlers from ERS payload on log records."""
+
+    def resolve(
+        self,
+        record: logging.LogRecord,
+        fallback_handlers : set[Any] 
+    ) -> set[Any] | None:
+        
+        del fallback_handlers # unused
+
+        # Chain None checks using walrus operator
+        if (
+            # Checks if python log level has an ERS severity level match
+            (ers_level_var := level_to_ers_var.get(record.levelno)) is None
+            # CHecks if ers_handlers (specifically for ERS) is supplied
+            or (ers_handlers := getattr(record, "ers_handlers", None)) is None
+            # _Assigns_ the relevant ERS handler conf from supplied level
+            or (ershandlerconf := ers_handlers.get(ers_level_var)) is None
+        ):
+            return None
+
+        return self.safe_return_set(ershandlerconf.handlers)
+        
+
+
+class StreamAwareAllowedHandlersStrategy(AllowedHandlersStrategy):
+    """A dispatcher, chooses specific strategies based on record.stream"""
+
+    def __init__(
+        self,
+        default_strategy : AllowedHandlersStrategy | None = None,
+        ers_strategy: AllowedHandlersStrategy | None = None,
+    ) -> None: 
+        self.default_strategy =  default_strategy or DefaultAllowedHandlerStrategy()
+        self.ers_strategy = ers_strategy or ERSAllowedHandlersStrategy()
+
+    def resolve(
+        self,
+        record: logging.LogRecord,
+        fallback_handlers : set[Any],
+        ) -> set[Any] | None:
+
+        if getattr(record, "stream", None) == StreamType.ERS:
+            return self.ers_strategy.resolve(record, fallback_handlers)
+        return self.default_strategy.resolve(record, fallback_handlers)
+    

--- a/src/daqpytools/logging/routing.py
+++ b/src/daqpytools/logging/routing.py
@@ -6,12 +6,13 @@ from daqpytools.logging.handlerconf import StreamType
 from daqpytools.logging.levels import level_to_ers_var
 
 """
-So this file basically allows us to define the set of handlers that the logger should send to 
+This module defines strategies that decide which handlers a logger should emit
+to for each record.
 """
 
 
 class AllowedHandlersStrategy(ABC):
-    """Strategy for resolving allowed handler types for a log record"""
+    """Strategy for resolving allowed handler types for a log record."""
 
     @abstractmethod
     def resolve(
@@ -22,18 +23,20 @@ class AllowedHandlersStrategy(ABC):
         """Resolve allowd handlers for a given record."""
 
     def safe_return_set(self, raw_set : set[Any]) -> set[Any] | None:
+        """Return a set without `None` values, or `None` if empty."""
         return {obj for obj in raw_set if obj is not None}
 
 
 
 class DefaultAllowedHandlerStrategy(AllowedHandlersStrategy):
-    """Resolve allowed handlers from record.handlers, or a fallback case"""
+    """Resolve allowed handlers from `record.handlers` or a fallback set."""
 
     def resolve(
         self,
         record: logging.LogRecord,
         fallback_handlers : set[Any]
     ) -> set[Any] | None:
+        """Resolve handlers from the record or fallback handlers."""
         allowed = getattr(record, "handlers", fallback_handlers)
         if allowed is None:
             return None
@@ -47,7 +50,7 @@ class ERSAllowedHandlersStrategy(AllowedHandlersStrategy):
         record: logging.LogRecord,
         fallback_handlers : set[Any] 
     ) -> set[Any] | None:
-        
+        """Resolve handlers from ERS metadata attached to the record."""
         del fallback_handlers # unused
 
         # Chain None checks using walrus operator
@@ -66,13 +69,14 @@ class ERSAllowedHandlersStrategy(AllowedHandlersStrategy):
 
 
 class StreamAwareAllowedHandlersStrategy(AllowedHandlersStrategy):
-    """A dispatcher, chooses specific strategies based on record.stream"""
+    """Dispatch to a strategy based on `record.stream`."""
 
     def __init__(
         self,
         default_strategy : AllowedHandlersStrategy | None = None,
         ers_strategy: AllowedHandlersStrategy | None = None,
     ) -> None: 
+        """Initialize strategy dispatchers for default and ERS streams."""
         self.default_strategy =  default_strategy or DefaultAllowedHandlerStrategy()
         self.ers_strategy = ers_strategy or ERSAllowedHandlersStrategy()
 
@@ -81,7 +85,7 @@ class StreamAwareAllowedHandlersStrategy(AllowedHandlersStrategy):
         record: logging.LogRecord,
         fallback_handlers : set[Any],
         ) -> set[Any] | None:
-
+        """Resolve handlers using stream-aware strategy selection."""
         if getattr(record, "stream", None) == StreamType.ERS:
             return self.ers_strategy.resolve(record, fallback_handlers)
         return self.default_strategy.resolve(record, fallback_handlers)

--- a/src/daqpytools/logging/specs.py
+++ b/src/daqpytools/logging/specs.py
@@ -13,7 +13,7 @@ from typing import Any
 class HandlerSpec:
     representative_type: Any
     handler_type: type[logging.Handler]
-    factory: Callable[[Mapping[str, Any]], logging.Handler]
+    factory: Callable[..., logging.Handler]
     filter_handler_ids: tuple[Any, ...] # For HandleIDFilter
     target_stream: io.IOBase| None = None
 

--- a/src/daqpytools/logging/specs.py
+++ b/src/daqpytools/logging/specs.py
@@ -1,25 +1,51 @@
+"""Declarative specifications used to construct logging handlers and filters.
+
+This module defines immutable spec objects that describe:
+- how a handler or filter is built (`factory`),
+- how it is identified at runtime (`handler_class` / `filter_class`), and
+- which handler types should be used for fallback routing (`fallback_types`).
+"""
+
 import io
 import logging
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
-"""
- Declarative specification for building and identifying objects
-"""
-
 
 @dataclass(frozen=True)
 class HandlerSpec:
-    representative_type: Any
-    handler_type: type[logging.Handler]
+    """Specification for creating and identifying a logging handler.
+
+    Attributes:
+        alias: Canonical identifier for the spec (typically a `HandlerType`).
+        handler_class: Runtime logging class used to detect existing handlers.
+        factory: Callable that builds the handler instance from configuration extras.
+        fallback_types: Handler types this handler maps to for fallback behavior.
+        target_stream: Optional stream discriminator for stream-based handlers
+            (for example, stdout vs stderr).
+    """
+
+    alias: Any
+    handler_class: type[logging.Handler]
     factory: Callable[..., logging.Handler]
-    filter_handler_ids: tuple[Any, ...] # For HandleIDFilter
-    target_stream: io.IOBase| None = None
+    fallback_types: tuple[Any, ...]
+    target_stream: io.IOBase | None = None
 
 
 @dataclass(frozen=True)
 class FilterSpec:
-    representative_type: Any
-    filter_type: type[logging.Filter]
+    """Specification for creating and identifying a logging filter.
+
+    Attributes:
+        alias: Canonical identifier for the spec (typically a `HandlerType`).
+        filter_class: Runtime logging filter class used to detect existing filters.
+        factory: Callable that builds the filter from fallback handlers and extras.
+        fallback_types: Default handler types passed to the filter factory when
+            no explicit fallback set is provided by the caller.
+    """
+
+    alias: Any
+    filter_class: type[logging.Filter]
     factory: Callable[[set[Any], Mapping[str, Any]], logging.Filter]
+    fallback_types: tuple[Any, ...] = tuple()

--- a/src/daqpytools/logging/specs.py
+++ b/src/daqpytools/logging/specs.py
@@ -48,4 +48,4 @@ class FilterSpec:
     alias: Any
     filter_class: type[logging.Filter]
     factory: Callable[[set[Any], Mapping[str, Any]], logging.Filter]
-    fallback_types: tuple[Any, ...] = tuple()
+    fallback_types: tuple[Any, ...] = ()

--- a/src/daqpytools/logging/specs.py
+++ b/src/daqpytools/logging/specs.py
@@ -1,7 +1,8 @@
-import logging
-from dataclasses import dataclass
 import io
-from typing import Any, Callable, Mapping
+import logging
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
 
 """
  Declarative specification for building and identifying objects

--- a/src/daqpytools/logging/specs.py
+++ b/src/daqpytools/logging/specs.py
@@ -1,0 +1,24 @@
+import logging
+from dataclasses import dataclass
+import io
+from typing import Any, Callable, Mapping
+
+"""
+ Declarative specification for building and identifying objects
+"""
+
+
+@dataclass(frozen=True)
+class HandlerSpec:
+    representative_type: Any
+    handler_type: type[logging.Handler]
+    factory: Callable[[Mapping[str, Any]], logging.Handler]
+    filter_handler_ids: tuple[Any, ...] # For HandleIDFilter
+    target_stream: io.IOBase| None = None
+
+
+@dataclass(frozen=True)
+class FilterSpec:
+    representative_type: Any
+    filter_type: type[logging.Filter]
+    factory: Callable[[set[Any], Mapping[str, Any]], logging.Filter]

--- a/tests/logging/test_formatter.py
+++ b/tests/logging/test_formatter.py
@@ -61,3 +61,23 @@ def test_formatter_level_format():
 def test_formatter_message_content():
     """Validate the message content is included in the formatted message."""
     assert "Test message" in formatted_message
+
+
+def test_formatter_does_not_mutate_original_record_message():
+    """Ensure formatting does not mutate the original record message."""
+    markup_msg = "[bold red]Colorful[/bold red] text"
+    local_record = logging.LogRecord(
+        name=test_logger_name,
+        level=logging.INFO,
+        pathname="test_path.py",
+        lineno=test_line_no,
+        msg=markup_msg,
+        args=None,
+        exc_info=None,
+    )
+
+    formatter = LoggingFormatter()
+    formatted_output = formatter.format(local_record)
+
+    assert "Colorful text" in formatted_output
+    assert local_record.msg == markup_msg

--- a/tests/logging/test_logger.py
+++ b/tests/logging/test_logger.py
@@ -1,9 +1,11 @@
 import logging
 import tempfile
+from unittest.mock import MagicMock
 
 import pytest
 
 from daqpytools.logging.exceptions import LoggerSetupError
+from daqpytools.logging.handlers import logger_or_ancestors_have_handler
 from daqpytools.logging.logger import get_daq_logger, setup_root_logger
 
 test_logger_name = "test_logger"
@@ -209,3 +211,17 @@ def test_get_daq_logger(caplog: pytest.LogCaptureFixture):
 
     # Shutdown logging to reset any internal state
     logging.shutdown()
+
+
+def test_logger_parent_walk_handles_mock_logger_cycle():
+    """Ensure parent traversal does not hang on mock logger-like objects."""
+    fake_logger = MagicMock()
+    fake_parent = MagicMock()
+
+    fake_logger.parent = fake_parent
+    fake_parent.parent = fake_parent
+
+    assert (
+        logger_or_ancestors_have_handler(fake_logger, True, logging.NullHandler)
+        is False
+    )


### PR DESCRIPTION
# Description

Fixes DUNE-DAQ/drunc#776
Fixes #48
Fixes #51 

This is a long time coming


Superseeds #53 #49


## Context

**For some more comprehensive set of logic ideas, please refer to the attached slides**

[ers_refactor.pdf](https://github.com/user-attachments/files/25684912/ers_refactor.pdf)


During testing of drunc, it was identified that we should be able to configure the handlers of a logging instance based on the ERS config supplied. This posed a greater question of how we deal with configuring the initialisation of handlers for loggers in general. Keep in mind that so far the features of the LogHandlerConf are entirely used for filtering; this is completely separate compared to how the logging was initialised.


A couple of key points are identified:

- We need to be able to add the ERS handlers automatically to the logging instance, based on what handlers are used in the entirity of ERS
- There needs to be a way for the logger to remember what handlers it was initialised with, and only use those if no `extra` argument was used to choose which Handler to use
  - The problem is that adding handlers to the logger is easy, but by default a logger will use _all_ available handlers when sending a message
  - When configuring ERS handlers, _all_ these will be added to the logger. Any usual message will therefore be sent to all the handlers that exist, which is not what we want.
  - This should happen by default; we do not want to modify drunc and add in `extra=HandlerType.Rich...` in every message
  - There is functionality to filter on which handler to use on a per message level, and also functionality for the filter to default to a specific set of handlers when none are used
  - This needs to be further expanded on to deal with ERS

The changes here are meant to tackle the above.



## Changes

### Fallback Handlers

The concept of Fallback Handlers are introduced. These are basically the 'default case' for what happens when log message is put in. 

Basically, when a user writes in  `log.info("msg")`, the code will parse it as `log.info("msg", extra={"handlers": fallback_handlers}`. This happens at the filtering stage of each handler, so at each `HandleIDFilter` attached to every handler. 

By default, the fallback handler for each handler is set to be itself, thereby following the default behaviour. Eg. the HandleIDFilter attached to the Rich handler will have the fallback handler to HandlerType.Rich, which will allow every message to pass.

The user experience is quite straight forward:

<details>

<summary>
Test exceprt
</summary>

```python
    fallback_log: logging.Logger = get_daq_logger(
        logger_name="fallback_logger",
        log_level=log_level,
        stream_handlers=False,
        rich_handler=True, # Only rich has been added
    )

    # As rich has been added, only rich should be used
    fallback_log.info("Rich Only")
    
    # Adding a stdout handler as usual
    ### Importantly, by default the fallback_handler will use HandlerType.stdout (for this case)
    ### So that it will fire automatically by default if no extras are added
    add_stdout_handler(fallback_log, True)

    # Adding an stderr handler with a fallback_handler to Unknown
    ### This makes it so that if no extra exist, then the attached filter will default check if 
    ### stderr == unknown
    ### Basically, the code then does an equivalent of 
    ### log.warning("msg", extra={HandlerType.Unknown})
    ### Which obviously fails for the stderr case
    add_stderr_handler(fallback_log, True, {HandlerType.Unknown})


    ## Result is that both RICH and STDout pass, but stderr fails because it defaults to nonworking
    fallback_log.critical("Rich + stdout only")
    
    ## Ofcourse, the handler still exists.
    ## so if you manually call it using the extra feature, it will print
    fallback_log.critical(
        "Rich + stdout + stderr",
        extra={"handlers": [HandlerType.Rich, HandlerType.Stream]},
    )

```

</details>


All the details on how it works is in the annotated text above from a users perspective. 
By default, it will set it to whatever the current handlertype is. 

For example, `add_rich_handler` will make the default case a `HandlerType.Rich`.



### Setup ERS Handlers

A new function called `setup_daq_ers_logger` has been implemented.

With everything set up, this is a relatively simple function. All it does is to get the oks configuration, gets a set of all HandlerTypes, and then passess it to `add_handlers_from_types` to get it added to the loggers. 

**Importantly**, the fallback_handlers for this is set to `HandlerType.Unknown`. This means that none of the new handlers added by the function will not be called unless specifically requested for!


### logging demonstrator

Of course, the logging demonstrator has been updated.

### Change topic name in ERS

Oh yeah I also fixed the ability to choose which session name the ERS handler goes to now.






## Major refactor of the code

See the previously linked set of slides for the description, but in general we have now new set of files:
- handlers.py -> where the handlers are defined
- handlerconf.py -> definition of LogHandlerConf and related
- rich_handler.py -> holds just the formattedrichhandler, helps for internal logging
- routing.py -> logic behind selecting which handlers are presented
- specs.py -> definition for specs to be used by handlers.py


The nicest new features are as follows:
- complete separation of logic between 'what handlers do i need to check' and actually checking if the handler is in the list of handlers being checked against. Means that installing new routing should be straightforward, in case they want to be changed
- Handers now defined by their handler spec, which contains the complete set of instructions on how to build and install a handler. 
- This is stored in a handler registry, which maps a HandlerType to a handler spec
- Which then allows us to have a generalised `add_handlers` function, that will add a handler based on which handlertype you call it with. 
- Handler building uses **kwargs, just like matplotlib, so its infinitely extendable


### Better imports

With this change, I added a couple of the useful imports in the `__init__.py` file. This makes things much easier for users of daqpytools since they can just do `from daqpytools.logging import x` rather than having to know what each of the files do and stuff.


## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)


To test:

- Run the monster: `daqpytools-logging-demonstrator -eh -hc -r -f log.log -ht -fh -s -ep emir-test -t` or similar
  - Check that each message in the initial example displays as expected (1 rich + 1 stdout, with a +1 stderr on eerror and above)
  - Check that the colors still exist in the example displays
  - Check that throttling works as expected
  - Check handlerconf works as expected
  - Check that the expected ERS messages appear
  - Check fallback_loggers demonstrator works
  - Check ersconfig demonstrator works

These are vague ish instructions, but they should be relatively clear based on the messages in the demonstrator itself

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))


